### PR TITLE
refactor: implement BlobHandle class for blob operations instead of B…

### DIFF
--- a/ArmoniK.Extension.CSharp.Client/Common/Domain/Blob/BlobInfo.cs
+++ b/ArmoniK.Extension.CSharp.Client/Common/Domain/Blob/BlobInfo.cs
@@ -19,7 +19,7 @@ namespace ArmoniK.Extension.CSharp.Client.Common.Domain.Blob;
 /// <summary>
 ///   Represents information that minimally defines a blob.
 /// </summary>
-public record class BlobInfo
+public record BlobInfo
 {
   /// <summary>
   ///   Session ID associated with the blob.

--- a/Tests/Configuration/MockedArmoniKClient.cs
+++ b/Tests/Configuration/MockedArmoniKClient.cs
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using ArmoniK.Extension.CSharp.Client;
 using ArmoniK.Extension.CSharp.Client.Common;
 using ArmoniK.Extension.CSharp.Client.Common.Domain.Task;
 using ArmoniK.Extension.CSharp.Client.Common.Services;
@@ -103,6 +104,14 @@ internal sealed class MockedArmoniKClient
 
   public IHealthCheckService HealthCheckService
     => serviceProvider_.GetRequiredService<IHealthCheckService>();
+
+  /// <summary>
+  ///   Implicit conversion to ArmoniKClient for compatibility with handlers.
+  /// </summary>
+  public static implicit operator ArmoniKClient(MockedArmoniKClient mockedClient)
+    => new(mockedClient.Properties,
+           mockedClient.LoggerFactory,
+           mockedClient.TaskOptions);
 
   private IBlobService BuildBlobService(IServiceProvider provider)
     => new BlobService(ChannelPool,

--- a/Tests/Handlers/BlobHandleTests.cs
+++ b/Tests/Handlers/BlobHandleTests.cs
@@ -1,0 +1,137 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2025. All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using ArmoniK.Extension.CSharp.Client;
+using ArmoniK.Extension.CSharp.Client.Common.Domain.Blob;
+using ArmoniK.Extension.CSharp.Client.Handlers;
+
+using NUnit.Framework;
+
+using Tests.Configuration;
+
+namespace Tests.Handlers;
+
+[TestFixture]
+public class BlobHandleTests
+{
+  [SetUp]
+  public void SetUp()
+  {
+    mockedArmoniKClient_ = new MockedArmoniKClient();
+    mockBlobInfo_ = new BlobInfo
+                    {
+                      BlobName  = "testBlob",
+                      SessionId = "testSession",
+                      BlobId    = "testBlobId",
+                    };
+  }
+
+  private MockedArmoniKClient? mockedArmoniKClient_;
+  private BlobInfo?            mockBlobInfo_;
+
+  [Test]
+  public void ConstructorWithBlobInfosShouldInitializeProperties()
+  {
+    var blobHandle = new BlobHandle(mockBlobInfo_,
+                                    mockedArmoniKClient_!);
+
+    Assert.Multiple(() =>
+                    {
+                      Assert.That(blobHandle.BlobInfo,
+                                  Is.EqualTo(mockBlobInfo_));
+                      Assert.That(blobHandle.ArmoniKClient,
+                                  Is.Not.Null);
+                      Assert.That(blobHandle.ArmoniKClient,
+                                  Is.InstanceOf<ArmoniKClient>());
+                    });
+  }
+
+  [Test]
+  public void ConstructorWithIndividualParametersShouldInitializeCorrectly()
+  {
+    var blobName  = "myBlob";
+    var blobId    = "myId";
+    var sessionId = "mySession";
+
+    var blobHandle = new BlobHandle(blobName,
+                                    blobId,
+                                    sessionId,
+                                    mockedArmoniKClient_!);
+
+    Assert.Multiple(() =>
+                    {
+                      Assert.That(blobHandle.BlobInfo.BlobName,
+                                  Is.EqualTo(blobName));
+                      Assert.That(blobHandle.BlobInfo.BlobId,
+                                  Is.EqualTo(blobId));
+                      Assert.That(blobHandle.BlobInfo.SessionId,
+                                  Is.EqualTo(sessionId));
+                      Assert.That(blobHandle.ArmoniKClient,
+                                  Is.Not.Null);
+                    });
+  }
+
+  [Test]
+  public void ConstructorWithBlobInfoThrowsArgumentNullExceptionWhenBlobInfoIsNull()
+    => Assert.That(() => new BlobHandle(null,
+                                        mockedArmoniKClient_!),
+                   Throws.ArgumentNullException.With.Property(nameof(ArgumentNullException.ParamName))
+                         .EqualTo("blobInfo"));
+
+  [Test]
+  public void ConstructorWithBlobInfo_ThrowsArgumentNullException_WhenClientIsNull()
+    => Assert.That(() => new BlobHandle(mockBlobInfo_,
+                                        null),
+                   Throws.ArgumentNullException.With.Property(nameof(ArgumentNullException.ParamName))
+                         .EqualTo("armoniKClient"));
+
+  [Test]
+  public void ImplicitConversionToBlobInfoShouldReturnCorrectBlobInfo()
+  {
+    var blobHandle = new BlobHandle(mockBlobInfo_,
+                                    mockedArmoniKClient_!);
+
+    BlobInfo convertedBlobInfo = blobHandle;
+
+    Assert.That(convertedBlobInfo,
+                Is.EqualTo(mockBlobInfo_));
+  }
+
+  [Test]
+  public void ImplicitConversionToBlobInfoThrowsArgumentNullExceptionWhenHandleIsNull()
+  {
+    BlobHandle? nullHandle = null;
+
+    Assert.That(() =>
+                {
+                  BlobInfo _ = nullHandle;
+                },
+                Throws.ArgumentNullException.With.Property(nameof(ArgumentNullException.ParamName))
+                      .EqualTo("blobHandle"));
+  }
+
+  [Test]
+  public void ImplicitConversionWorksInMethodParameters()
+  {
+    var blobHandle = new BlobHandle(mockBlobInfo_,
+                                    mockedArmoniKClient_!);
+
+    // we make sure that we can use BlobHandle where BlobInfo is expected
+    Assert.That(() => Assert.That(blobHandle,
+                                  Is.Not.Null),
+                Throws.Nothing);
+  }
+}


### PR DESCRIPTION
# Motivation

The changes are aimed at improving code clarity and reusability by restructuring how blob information is handled.

# Description

1. Renamed the class to `BlobHandle` to better reflect its purpose and usage within the system.
2. Implement implicit conversion operator from `BlobHandle` --> `BlobInfo` and `BlobInfo` + `ArmoniKClient` --> `BlobHandle`
3. Implement tests to check conversion

# Testing

Ran ok, tests too.

# Impact

The impact of these modifications includes:

- **Code Clarity**: Renaming to `BlobHandle` makes the code more understandable.
- **Flexibility**: Inheriting from `BlobInfo` allows for more versatile use of `BlobHandle` in the codebase.

# Additional Information



# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
