### PR TITLE
chore: add missing properties in TaskState and TaskSummary

### DIFF
--- a/ArmoniK.Extensions.CSharp.Client/Common/Domain/Task/TaskSummary.cs
+++ b/ArmoniK.Extensions.CSharp.Client/Common/Domain/Task/TaskSummary.cs
@@ -57,9 +57,44 @@ public class TaskSummary
   public TaskConfiguration TaskOptions { get; set; } = new();
 
   /// <summary>
+  ///   The ID of the Task that as submitted this task if any.
+  /// </summary>
+  public string? CreatedBy { get; init; } = string.Empty;
+
+  /// <summary>
   ///   Time when the task was created.
   /// </summary>
-  public DateTime CreateAt { get; init; }
+  public DateTime CreatedAt { get; init; }
+
+  /// <summary>
+  ///   The task submission date.
+  /// </summary>
+  public DateTime SubmittedAt { get; init; }
+
+  /// <summary>
+  ///   When the task is received by the agent.
+  /// </summary>
+  public DateTime? ReceivedAt { get; init; }
+
+  /// <summary>
+  ///   When the task is acquired by the agent.
+  /// </summary>
+  public DateTime? AcquiredAt { get; init; }
+
+  /// <summary>
+  ///   Task data retrieval end date.
+  /// </summary>
+  public DateTime? FetchedAt { get; init; }
+
+  /// <summary>
+  ///   The end of task processing date.
+  /// </summary>
+  public DateTime? ProcessedAt { get; init; }
+
+  /// <summary>
+  ///   The pod Time To Live.
+  /// </summary>
+  public DateTime? PodTTL { get; init; }
 
   /// <summary>
   ///   Time when the task ended.
@@ -72,9 +107,39 @@ public class TaskSummary
   public DateTime? StartedAt { get; init; }
 
   /// <summary>
+  ///   The task duration. Between the creation date and the end date.
+  /// </summary>
+  public TimeSpan? CreationToEnd { get; init; }
+
+  /// <summary>
+  ///   The task calculated duration. Between the start date and the end date.
+  /// </summary>
+  public TimeSpan? ProcessingToEnd { get; init; }
+
+  /// <summary>
+  ///   The task calculated duration. Between the received date and the end date.
+  /// </summary>
+  public TimeSpan? ReceivedToEnd { get; init; }
+
+  /// <summary>
   ///   Current status of the task.
   /// </summary>
   public TaskStatus Status { get; init; }
+
+  /// <summary>
+  ///   The owner pod ID.
+  /// </summary>
+  public string OwnerPodId { get; init; } = string.Empty;
+
+  /// <summary>
+  ///   The hostname of the container running the task.
+  /// </summary>
+  public string PodHostName { get; init; } = string.Empty;
+
+  /// <summary>
+  ///   The initial task ID. Set when a task is submitted independently of retries.
+  /// </summary>
+  public string InitialTaskId { get; init; } = string.Empty;
 }
 
 /// <summary>
@@ -94,10 +159,23 @@ public static class TaskSummaryExt
          ExpectedOutputsCount  = taskSummary.CountExpectedOutputIds,
          TaskId                = taskSummary.Id,
          Status                = taskSummary.Status.ToInternalStatus(),
-         CreateAt              = taskSummary.CreatedAt.ToDateTime(),
+         CreatedBy             = taskSummary.CreatedBy,
+         CreatedAt             = taskSummary.CreatedAt.ToDateTime(),
+         SubmittedAt           = taskSummary.SubmittedAt.ToDateTime(),
+         ReceivedAt            = taskSummary.ReceivedAt?.ToDateTime(),
+         AcquiredAt            = taskSummary.AcquiredAt?.ToDateTime(),
+         FetchedAt             = taskSummary.FetchedAt?.ToDateTime(),
+         ProcessedAt           = taskSummary.ProcessedAt?.ToDateTime(),
+         PodTTL                = taskSummary.PodTtl?.ToDateTime(),
          StartedAt             = taskSummary.StartedAt?.ToDateTime(),
+         CreationToEnd         = taskSummary.CreationToEndDuration?.ToTimeSpan(),
+         ProcessingToEnd       = taskSummary.ProcessingToEndDuration?.ToTimeSpan(),
+         ReceivedToEnd         = taskSummary.ReceivedToEndDuration?.ToTimeSpan(),
          EndedAt               = taskSummary.EndedAt?.ToDateTime(),
          SessionId             = taskSummary.SessionId,
          PayloadId             = taskSummary.PayloadId,
+         OwnerPodId            = taskSummary.OwnerPodId,
+         PodHostName           = taskSummary.PodHostname,
+         InitialTaskId         = taskSummary.InitialTaskId,
        };
 }

--- a/ArmoniK.Extensions.CSharp.Client/Common/Domain/Task/TaskSummary.cs
+++ b/ArmoniK.Extensions.CSharp.Client/Common/Domain/Task/TaskSummary.cs
@@ -54,7 +54,7 @@ public class TaskSummary
   /// <summary>
   ///   Gets the configuration options for the task, which may be null if no additional configurations are specified.
   /// </summary>
-  public TaskConfiguration TaskOptions { get; set; } = new();
+  public TaskConfiguration TaskOptions { get; } = new();
 
   /// <summary>
   ///   The ID of the Task that as submitted this task if any.

--- a/ArmoniK.Extensions.CSharp.Client/Queryable/TaskSummaryQuery/TaskSummaryMaps.cs
+++ b/ArmoniK.Extensions.CSharp.Client/Queryable/TaskSummaryQuery/TaskSummaryMaps.cs
@@ -20,6 +20,8 @@ using System.Collections.Generic;
 using ArmoniK.Api.gRPC.V1.Tasks;
 using ArmoniK.Extensions.CSharp.Common.Common.Domain.Task;
 
+using TaskSummary = ArmoniK.Extensions.CSharp.Client.Common.Domain.Task.TaskSummary;
+
 namespace ArmoniK.Extensions.CSharp.Client.Queryable.TaskSummaryQuery;
 
 internal static class TaskSummaryMaps
@@ -27,25 +29,67 @@ internal static class TaskSummaryMaps
   public static readonly Dictionary<string, TaskSummaryEnumField> MemberName2EnumField_ = new()
                                                                                           {
                                                                                             {
-                                                                                              nameof(TaskInfos.TaskId), TaskSummaryEnumField.TaskId
+                                                                                              nameof(TaskSummary.TaskId), TaskSummaryEnumField.TaskId
                                                                                             },
                                                                                             {
-                                                                                              nameof(TaskInfos.PayloadId), TaskSummaryEnumField.PayloadId
+                                                                                              nameof(TaskSummary.PayloadId), TaskSummaryEnumField.PayloadId
                                                                                             },
                                                                                             {
-                                                                                              nameof(TaskInfos.SessionId), TaskSummaryEnumField.SessionId
+                                                                                              nameof(TaskSummary.SessionId), TaskSummaryEnumField.SessionId
                                                                                             },
                                                                                             {
-                                                                                              nameof(TaskState.CreateAt), TaskSummaryEnumField.CreatedAt
+                                                                                              nameof(TaskSummary.CreatedBy), TaskSummaryEnumField.CreatedBy
                                                                                             },
                                                                                             {
-                                                                                              nameof(TaskState.EndedAt), TaskSummaryEnumField.EndedAt
+                                                                                              nameof(TaskSummary.CreatedAt), TaskSummaryEnumField.CreatedAt
                                                                                             },
                                                                                             {
-                                                                                              nameof(TaskState.StartedAt), TaskSummaryEnumField.StartedAt
+                                                                                              nameof(TaskSummary.SubmittedAt), TaskSummaryEnumField.SubmittedAt
                                                                                             },
                                                                                             {
-                                                                                              nameof(TaskState.Status), TaskSummaryEnumField.Status
+                                                                                              nameof(TaskSummary.AcquiredAt), TaskSummaryEnumField.AcquiredAt
+                                                                                            },
+                                                                                            {
+                                                                                              nameof(TaskSummary.FetchedAt), TaskSummaryEnumField.FetchedAt
+                                                                                            },
+                                                                                            {
+                                                                                              nameof(TaskSummary.ProcessedAt), TaskSummaryEnumField.ProcessedAt
+                                                                                            },
+                                                                                            {
+                                                                                              nameof(TaskSummary.PodTTL), TaskSummaryEnumField.PodTtl
+                                                                                            },
+                                                                                            {
+                                                                                              nameof(TaskSummary.ReceivedAt), TaskSummaryEnumField.ReceivedAt
+                                                                                            },
+                                                                                            {
+                                                                                              nameof(TaskSummary.EndedAt), TaskSummaryEnumField.EndedAt
+                                                                                            },
+                                                                                            {
+                                                                                              nameof(TaskSummary.StartedAt), TaskSummaryEnumField.StartedAt
+                                                                                            },
+                                                                                            {
+                                                                                              nameof(TaskSummary.CreationToEnd),
+                                                                                              TaskSummaryEnumField.CreationToEndDuration
+                                                                                            },
+                                                                                            {
+                                                                                              nameof(TaskSummary.ProcessingToEnd),
+                                                                                              TaskSummaryEnumField.ProcessingToEndDuration
+                                                                                            },
+                                                                                            {
+                                                                                              nameof(TaskSummary.ReceivedToEnd),
+                                                                                              TaskSummaryEnumField.ReceivedToEndDuration
+                                                                                            },
+                                                                                            {
+                                                                                              nameof(TaskSummary.Status), TaskSummaryEnumField.Status
+                                                                                            },
+                                                                                            {
+                                                                                              nameof(TaskSummary.OwnerPodId), TaskSummaryEnumField.OwnerPodId
+                                                                                            },
+                                                                                            {
+                                                                                              nameof(TaskSummary.PodHostName), TaskSummaryEnumField.PodHostname
+                                                                                            },
+                                                                                            {
+                                                                                              nameof(TaskSummary.InitialTaskId), TaskSummaryEnumField.InitialTaskId
                                                                                             },
                                                                                           };
 
@@ -68,25 +112,64 @@ internal static class TaskSummaryMaps
   public static readonly Dictionary<string, Type> MemberName2Type_ = new()
                                                                      {
                                                                        {
-                                                                         nameof(TaskInfos.TaskId), typeof(string)
+                                                                         nameof(TaskSummary.TaskId), typeof(string)
                                                                        },
                                                                        {
-                                                                         nameof(TaskInfos.PayloadId), typeof(string)
+                                                                         nameof(TaskSummary.PayloadId), typeof(string)
                                                                        },
                                                                        {
-                                                                         nameof(TaskInfos.SessionId), typeof(string)
+                                                                         nameof(TaskSummary.SessionId), typeof(string)
                                                                        },
                                                                        {
-                                                                         nameof(TaskState.CreateAt), typeof(DateTime)
+                                                                         nameof(TaskSummary.CreatedBy), typeof(string)
                                                                        },
                                                                        {
-                                                                         nameof(TaskState.EndedAt), typeof(DateTime)
+                                                                         nameof(TaskSummary.CreatedAt), typeof(DateTime)
                                                                        },
                                                                        {
-                                                                         nameof(TaskState.StartedAt), typeof(DateTime)
+                                                                         nameof(TaskSummary.SubmittedAt), typeof(DateTime)
                                                                        },
                                                                        {
-                                                                         nameof(TaskState.Status), typeof(TaskStatus)
+                                                                         nameof(TaskSummary.AcquiredAt), typeof(DateTime)
+                                                                       },
+                                                                       {
+                                                                         nameof(TaskSummary.FetchedAt), typeof(DateTime)
+                                                                       },
+                                                                       {
+                                                                         nameof(TaskSummary.ProcessedAt), typeof(DateTime)
+                                                                       },
+                                                                       {
+                                                                         nameof(TaskSummary.PodTTL), typeof(DateTime)
+                                                                       },
+                                                                       {
+                                                                         nameof(TaskSummary.ReceivedAt), typeof(DateTime)
+                                                                       },
+                                                                       {
+                                                                         nameof(TaskSummary.EndedAt), typeof(DateTime)
+                                                                       },
+                                                                       {
+                                                                         nameof(TaskSummary.StartedAt), typeof(DateTime)
+                                                                       },
+                                                                       {
+                                                                         nameof(TaskSummary.CreationToEnd), typeof(TimeSpan)
+                                                                       },
+                                                                       {
+                                                                         nameof(TaskSummary.ProcessingToEnd), typeof(TimeSpan)
+                                                                       },
+                                                                       {
+                                                                         nameof(TaskSummary.ReceivedToEnd), typeof(TimeSpan)
+                                                                       },
+                                                                       {
+                                                                         nameof(TaskSummary.Status), typeof(TaskStatus)
+                                                                       },
+                                                                       {
+                                                                         nameof(TaskSummary.OwnerPodId), typeof(string)
+                                                                       },
+                                                                       {
+                                                                         nameof(TaskSummary.PodHostName), typeof(string)
+                                                                       },
+                                                                       {
+                                                                         nameof(TaskSummary.InitialTaskId), typeof(string)
                                                                        },
                                                                        {
                                                                          nameof(TaskConfiguration.MaxDuration), typeof(TimeSpan)

--- a/ArmoniK.Extensions.CSharp.Common/Common/Domain/Task/TaskOptionExt.cs
+++ b/ArmoniK.Extensions.CSharp.Common/Common/Domain/Task/TaskOptionExt.cs
@@ -14,12 +14,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Linq;
+
 using ArmoniK.Api.gRPC.V1;
-using ArmoniK.Extensions.CSharp.Common.Common.Domain.Task;
 using ArmoniK.Extensions.CSharp.Common.Exceptions;
 using ArmoniK.Extensions.CSharp.Common.Library;
 
-namespace ArmoniK.Extensions.CSharp.Worker.Common.Domain.Task;
+namespace ArmoniK.Extensions.CSharp.Common.Common.Domain.Task;
 
 /// <summary>
 ///   Provides extension methods for TaskOptions
@@ -36,7 +37,8 @@ public static class TaskOptionExt
            taskOption.Priority,
            taskOption.PartitionId,
            taskOption.MaxDuration.ToTimeSpan(),
-           taskOption.Options.ToDictionary());
+           taskOption.Options.ToDictionary(pair => pair.Key,
+                                           pair => pair.Value));
 
   /// <summary>
   ///   Get a DynamicLibrary from the TaskOptions.

--- a/ArmoniK.Extensions.CSharp.Common/Common/Domain/Task/TaskResult.cs
+++ b/ArmoniK.Extensions.CSharp.Common/Common/Domain/Task/TaskResult.cs
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace ArmoniK.Extensions.CSharp.Worker.Interfaces.Common.Domain.Task;
+namespace ArmoniK.Extensions.CSharp.Common.Common.Domain.Task;
 
 /// <summary>
 ///   Represent an ArmoniK task result

--- a/ArmoniK.Extensions.CSharp.Common/Common/Domain/Task/TaskState.cs
+++ b/ArmoniK.Extensions.CSharp.Common/Common/Domain/Task/TaskState.cs
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 
 using ArmoniK.Api.gRPC.V1.Tasks;
 
@@ -53,9 +54,44 @@ public record TaskState : TaskInfos
   }
 
   /// <summary>
+  ///   The ID of the Task that as submitted this task if any.
+  /// </summary>
+  public string? CreatedBy { get; init; } = string.Empty;
+
+  /// <summary>
   ///   Time when the task was created.
   /// </summary>
   public DateTime CreateAt { get; init; }
+
+  /// <summary>
+  ///   The task submission date.
+  /// </summary>
+  public DateTime SubmittedAt { get; init; }
+
+  /// <summary>
+  ///   When the task is received by the agent.
+  /// </summary>
+  public DateTime? ReceivedAt { get; init; }
+
+  /// <summary>
+  ///   When the task is acquired by the agent.
+  /// </summary>
+  public DateTime? AcquiredAt { get; init; }
+
+  /// <summary>
+  ///   Task data retrieval end date.
+  /// </summary>
+  public DateTime? FetchedAt { get; init; }
+
+  /// <summary>
+  ///   The end of task processing date.
+  /// </summary>
+  public DateTime? ProcessedAt { get; init; }
+
+  /// <summary>
+  ///   The pod Time To Live.
+  /// </summary>
+  public DateTime? PodTTL { get; init; }
 
   /// <summary>
   ///   Time when the task ended.
@@ -68,9 +104,59 @@ public record TaskState : TaskInfos
   public DateTime? StartedAt { get; init; }
 
   /// <summary>
+  ///   The task duration. Between the creation date and the end date.
+  /// </summary>
+  public TimeSpan? CreationToEnd { get; init; }
+
+  /// <summary>
+  ///   The task calculated duration. Between the start date and the end date.
+  /// </summary>
+  public TimeSpan? ProcessingToEnd { get; init; }
+
+  /// <summary>
+  ///   The task calculated duration. Between the received date and the end date.
+  /// </summary>
+  public TimeSpan? ReceivedToEnd { get; init; }
+
+  /// <summary>
   ///   Current status of the task.
   /// </summary>
   public TaskStatus Status { get; init; }
+
+  /// <summary>
+  ///   The status message.
+  /// </summary>
+  public string StatusMessage { get; init; } = string.Empty;
+
+  /// <summary>
+  ///   The owner pod ID.
+  /// </summary>
+  public string OwnerPodId { get; init; } = string.Empty;
+
+  /// <summary>
+  ///   The hostname of the container running the task.
+  /// </summary>
+  public string PodHostName { get; init; } = string.Empty;
+
+  /// <summary>
+  ///   The initial task ID. Set when a task is submitted independently of retries.
+  /// </summary>
+  public string InitialTaskId { get; init; } = string.Empty;
+
+  /// <summary>
+  ///   The parent task IDs. A tasks can be a child of another task.
+  /// </summary>
+  public IReadOnlyCollection<string> ParentTaskIds { get; init; } = [];
+
+  /// <summary>
+  ///   The retry of IDs. When a task fail, retry will use these set of IDs.
+  /// </summary>
+  public IReadOnlyCollection<string> RetryOfIds { get; init; } = [];
+
+  /// <summary>
+  ///   The task output.
+  /// </summary>
+  public TaskResult? Output { get; init; }
 }
 
 /// <summary>
@@ -247,5 +333,28 @@ public static class TaskStateExt
          EndedAt          = taskDetailed.EndedAt?.ToDateTime(),
          SessionId        = taskDetailed.SessionId,
          PayloadId        = taskDetailed.PayloadId,
+         SubmittedAt      = taskDetailed.SubmittedAt.ToDateTime(),
+         AcquiredAt       = taskDetailed.AcquiredAt?.ToDateTime(),
+         ReceivedAt       = taskDetailed.ReceivedAt?.ToDateTime(),
+         FetchedAt        = taskDetailed.FetchedAt?.ToDateTime(),
+         ProcessedAt      = taskDetailed.ProcessedAt?.ToDateTime(),
+         PodTTL           = taskDetailed.PodTtl?.ToDateTime(),
+         OwnerPodId       = taskDetailed.OwnerPodId,
+         PodHostName      = taskDetailed.PodHostname,
+         InitialTaskId    = taskDetailed.InitialTaskId,
+         ParentTaskIds    = taskDetailed.ParentTaskIds,
+         RetryOfIds       = taskDetailed.RetryOfIds,
+         CreatedBy        = taskDetailed.CreatedBy,
+         CreationToEnd    = taskDetailed.CreationToEndDuration?.ToTimeSpan(),
+         ProcessingToEnd  = taskDetailed.ProcessingToEndDuration?.ToTimeSpan(),
+         ReceivedToEnd    = taskDetailed.ReceivedToEndDuration?.ToTimeSpan(),
+         StatusMessage    = taskDetailed.StatusMessage,
+         TaskOptions      = taskDetailed.Options.ToTaskConfiguration(),
+         Output = taskDetailed.Output?.Success switch
+                  {
+                    null  => null,
+                    true  => TaskResult.Success,
+                    false => TaskResult.Failure(taskDetailed.Output.Error),
+                  },
        };
 }

--- a/ArmoniK.Extensions.CSharp.Common/Common/Domain/Task/TaskState.cs
+++ b/ArmoniK.Extensions.CSharp.Common/Common/Domain/Task/TaskState.cs
@@ -47,7 +47,7 @@ public record TaskState : TaskInfos
                    DateTime?  startedAt,
                    TaskStatus status)
   {
-    CreateAt  = createAt;
+    CreatedAt = createAt;
     EndedAt   = endedAt;
     StartedAt = startedAt;
     Status    = status;
@@ -61,7 +61,7 @@ public record TaskState : TaskInfos
   /// <summary>
   ///   Time when the task was created.
   /// </summary>
-  public DateTime CreateAt { get; init; }
+  public DateTime CreatedAt { get; init; }
 
   /// <summary>
   ///   The task submission date.
@@ -328,7 +328,7 @@ public static class TaskStateExt
          ExpectedOutputs  = taskDetailed.ExpectedOutputIds,
          TaskId           = taskDetailed.Id,
          Status           = taskDetailed.Status.ToInternalStatus(),
-         CreateAt         = taskDetailed.CreatedAt.ToDateTime(),
+         CreatedAt        = taskDetailed.CreatedAt.ToDateTime(),
          StartedAt        = taskDetailed.StartedAt?.ToDateTime(),
          EndedAt          = taskDetailed.EndedAt?.ToDateTime(),
          SessionId        = taskDetailed.SessionId,

--- a/ArmoniK.Extensions.CSharp.Common/Common/Domain/Task/TaskState.cs
+++ b/ArmoniK.Extensions.CSharp.Common/Common/Domain/Task/TaskState.cs
@@ -38,16 +38,16 @@ public record TaskState : TaskInfos
   /// <summary>
   ///   Initializes a new instance of the TaskState class with details about task timings and status.
   /// </summary>
-  /// <param name="createAt">The creation time of the task.</param>
+  /// <param name="createdAt">The creation time of the task.</param>
   /// <param name="endedAt">The end time of the task.</param>
   /// <param name="startedAt">The start time of the task.</param>
   /// <param name="status">The status of the task.</param>
-  public TaskState(DateTime   createAt,
+  public TaskState(DateTime   createdAt,
                    DateTime?  endedAt,
                    DateTime?  startedAt,
                    TaskStatus status)
   {
-    CreatedAt = createAt;
+    CreatedAt = createdAt;
     EndedAt   = endedAt;
     StartedAt = startedAt;
     Status    = status;

--- a/ArmoniK.Extensions.CSharp.DynamicWorker/DynamicServiceRequestContext.cs
+++ b/ArmoniK.Extensions.CSharp.DynamicWorker/DynamicServiceRequestContext.cs
@@ -16,8 +16,8 @@
 
 using ArmoniK.Api.gRPC.V1;
 using ArmoniK.Api.Worker.Worker;
+using ArmoniK.Extensions.CSharp.Common.Common.Domain.Task;
 using ArmoniK.Extensions.CSharp.Worker;
-using ArmoniK.Extensions.CSharp.Worker.Common.Domain.Task;
 using ArmoniK.Extensions.CSharp.Worker.Interfaces;
 
 namespace ArmoniK.Extensions.CSharp.DynamicWorker;

--- a/ArmoniK.Extensions.CSharp.Worker.Interfaces/IWorker.cs
+++ b/ArmoniK.Extensions.CSharp.Worker.Interfaces/IWorker.cs
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using ArmoniK.Extensions.CSharp.Worker.Interfaces.Common.Domain.Task;
+using ArmoniK.Extensions.CSharp.Common.Common.Domain.Task;
 
 using Microsoft.Extensions.Logging;
 

--- a/ArmoniK.Extensions.CSharp.Worker/SdkTaskRunner.cs
+++ b/ArmoniK.Extensions.CSharp.Worker/SdkTaskRunner.cs
@@ -19,8 +19,8 @@ using System.Text.Json;
 
 using ArmoniK.Api.gRPC.V1;
 using ArmoniK.Api.Worker.Worker;
+using ArmoniK.Extensions.CSharp.Common.Common.Domain.Task;
 using ArmoniK.Extensions.CSharp.Common.Exceptions;
-using ArmoniK.Extensions.CSharp.Worker.Common.Domain.Task;
 using ArmoniK.Extensions.CSharp.Worker.Interfaces;
 using ArmoniK.Extensions.CSharp.Worker.Interfaces.Handles;
 

--- a/DynamicWorkerExample/HelloWorker.cs
+++ b/DynamicWorkerExample/HelloWorker.cs
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using ArmoniK.Extensions.CSharp.Common.Common.Domain.Task;
 using ArmoniK.Extensions.CSharp.Worker.Interfaces;
-using ArmoniK.Extensions.CSharp.Worker.Interfaces.Common.Domain.Task;
 
 using Microsoft.Extensions.Logging;
 

--- a/End2EndTests/ArmoniK.EndToEndTests.Worker/Tests/CheckBlobCreationResponseOrderWorker.cs
+++ b/End2EndTests/ArmoniK.EndToEndTests.Worker/Tests/CheckBlobCreationResponseOrderWorker.cs
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using ArmoniK.Extensions.CSharp.Common.Common.Domain.Task;
 using ArmoniK.Extensions.CSharp.Worker.Interfaces;
 using ArmoniK.Extensions.CSharp.Worker.Interfaces.Common.Domain.Blob;
 using ArmoniK.Extensions.CSharp.Worker.Interfaces.Common.Domain.Task;

--- a/End2EndTests/ArmoniK.EndToEndTests.Worker/Tests/FailingTaskWorker.cs
+++ b/End2EndTests/ArmoniK.EndToEndTests.Worker/Tests/FailingTaskWorker.cs
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using ArmoniK.Extensions.CSharp.Common.Common.Domain.Task;
 using ArmoniK.Extensions.CSharp.Worker.Interfaces;
-using ArmoniK.Extensions.CSharp.Worker.Interfaces.Common.Domain.Task;
 
 using Microsoft.Extensions.Logging;
 

--- a/End2EndTests/ArmoniK.EndToEndTests.Worker/Tests/GaussProblemWorker.cs
+++ b/End2EndTests/ArmoniK.EndToEndTests.Worker/Tests/GaussProblemWorker.cs
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using ArmoniK.Extensions.CSharp.Common.Common.Domain.Task;
 using ArmoniK.Extensions.CSharp.Worker.Interfaces;
 using ArmoniK.Extensions.CSharp.Worker.Interfaces.Common.Domain.Blob;
 using ArmoniK.Extensions.CSharp.Worker.Interfaces.Common.Domain.Task;

--- a/End2EndTests/ArmoniK.EndToEndTests.Worker/Tests/PriorityWorker.cs
+++ b/End2EndTests/ArmoniK.EndToEndTests.Worker/Tests/PriorityWorker.cs
@@ -16,8 +16,8 @@
 
 using System.Text;
 
+using ArmoniK.Extensions.CSharp.Common.Common.Domain.Task;
 using ArmoniK.Extensions.CSharp.Worker.Interfaces;
-using ArmoniK.Extensions.CSharp.Worker.Interfaces.Common.Domain.Task;
 
 using Microsoft.Extensions.Logging;
 

--- a/End2EndTests/ArmoniK.EndToEndTests.Worker/Tests/TaskSdkWorker.cs
+++ b/End2EndTests/ArmoniK.EndToEndTests.Worker/Tests/TaskSdkWorker.cs
@@ -16,8 +16,8 @@
 
 using System.Text;
 
+using ArmoniK.Extensions.CSharp.Common.Common.Domain.Task;
 using ArmoniK.Extensions.CSharp.Worker.Interfaces;
-using ArmoniK.Extensions.CSharp.Worker.Interfaces.Common.Domain.Task;
 
 using Microsoft.Extensions.Logging;
 

--- a/StaticWorkerExample/HelloWorker.cs
+++ b/StaticWorkerExample/HelloWorker.cs
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using ArmoniK.Extensions.CSharp.Common.Common.Domain.Task;
 using ArmoniK.Extensions.CSharp.Worker.Interfaces;
-using ArmoniK.Extensions.CSharp.Worker.Interfaces.Common.Domain.Task;
 
 namespace StaticWorkerExample;
 

--- a/Tests/Common/Domain/TaskTests/TaskStateTests.cs
+++ b/Tests/Common/Domain/TaskTests/TaskStateTests.cs
@@ -38,7 +38,7 @@ public class TaskStateTests
                                   TaskStatus.Completed);
     Assert.Multiple(() =>
                     {
-                      Assert.That(taskState.CreateAt,
+                      Assert.That(taskState.CreatedAt,
                                   Is.EqualTo(createAt));
                       Assert.That(taskState.EndedAt,
                                   Is.EqualTo(endedAt));

--- a/Tests/Common/Domain/TaskTests/TaskStateTests.cs
+++ b/Tests/Common/Domain/TaskTests/TaskStateTests.cs
@@ -61,6 +61,8 @@ public class TaskStateTests
   [TestCase(TaskStatus.Processing)]
   [TestCase(TaskStatus.Processed)]
   [TestCase(TaskStatus.Retried)]
+  [TestCase(TaskStatus.Paused)]
+  [TestCase(TaskStatus.Pending)]
   [TestCase((TaskStatus)99)]
   public void TestTaskStatus(TaskStatus status)
   {
@@ -78,6 +80,8 @@ public class TaskStateTests
       case TaskStatus.Processing:
       case TaskStatus.Processed:
       case TaskStatus.Retried:
+      case TaskStatus.Paused:
+      case TaskStatus.Pending:
         var grpcStatus = status.ToGrpcStatus();
         Assert.That(grpcStatus.ToString(),
                     Is.EqualTo(status.ToString()));

--- a/Tests/Queryable/FilterTaskTests.cs
+++ b/Tests/Queryable/FilterTaskTests.cs
@@ -115,17 +115,236 @@ public class FilterTaskTests : BaseTaskFilterTests
   }
 
   [Test]
-  public void CreateAtFilterEqual()
+  public void CreatedByFilterEqual()
+  {
+    var client = new MockedArmoniKClient();
+
+    var filter = BuildOr(BuildAnd(BuildFilterString("CreatedBy",
+                                                    "==",
+                                                    "task1")));
+
+    var query = client.TasksService.AsQueryable()
+                      .Where(taskState => taskState.CreatedBy == "task1");
+
+    // Execute the query
+    var result = query.AsAsyncEnumerable()
+                      .ToListAsync();
+
+    var taskQueryProvider = (TaskSummaryQueryProvider)((ArmoniKQueryable<TaskSummary>)query).Provider;
+    Assert.That(taskQueryProvider.QueryExecution!.PaginationInstance,
+                Is.EqualTo(BuildTaskPagination(filter)));
+  }
+
+  [Test]
+  public void CreatedAtFilterEqual()
   {
     var client = new MockedArmoniKClient();
 
     var date = DateTime.UtcNow;
-    var filter = BuildOr(BuildAnd(BuildFilterDateTime("CreateAt",
+    var filter = BuildOr(BuildAnd(BuildFilterDateTime("CreatedAt",
                                                       "==",
                                                       date)));
 
     var query = client.TasksService.AsQueryable()
-                      .Where(taskState => taskState.CreateAt == date);
+                      .Where(taskState => taskState.CreatedAt == date);
+
+    // Execute the query
+    var result = query.AsAsyncEnumerable()
+                      .ToListAsync();
+
+    var taskQueryProvider = (TaskSummaryQueryProvider)((ArmoniKQueryable<TaskSummary>)query).Provider;
+    Assert.That(taskQueryProvider.QueryExecution!.PaginationInstance,
+                Is.EqualTo(BuildTaskPagination(filter)));
+  }
+
+  [Test]
+  public void SubmittedAtFilterEqual()
+  {
+    var client = new MockedArmoniKClient();
+
+    var date = DateTime.UtcNow;
+    var filter = BuildOr(BuildAnd(BuildFilterDateTime("SubmittedAt",
+                                                      "==",
+                                                      date)));
+
+    var query = client.TasksService.AsQueryable()
+                      .Where(taskState => taskState.SubmittedAt == date);
+
+    // Execute the query
+    var result = query.AsAsyncEnumerable()
+                      .ToListAsync();
+
+    var taskQueryProvider = (TaskSummaryQueryProvider)((ArmoniKQueryable<TaskSummary>)query).Provider;
+    Assert.That(taskQueryProvider.QueryExecution!.PaginationInstance,
+                Is.EqualTo(BuildTaskPagination(filter)));
+  }
+
+  [Test]
+  public void ReceivedAtFilterEqual()
+  {
+    var client = new MockedArmoniKClient();
+
+    var date = DateTime.UtcNow;
+    var filter = BuildOr(BuildAnd(BuildFilterDateTime("ReceivedAt",
+                                                      "==",
+                                                      date)));
+
+    var query = client.TasksService.AsQueryable()
+                      .Where(taskState => taskState.ReceivedAt == date);
+
+    // Execute the query
+    var result = query.AsAsyncEnumerable()
+                      .ToListAsync();
+
+    var taskQueryProvider = (TaskSummaryQueryProvider)((ArmoniKQueryable<TaskSummary>)query).Provider;
+    Assert.That(taskQueryProvider.QueryExecution!.PaginationInstance,
+                Is.EqualTo(BuildTaskPagination(filter)));
+  }
+
+  [Test]
+  public void AcquiredAtFilterEqual()
+  {
+    var client = new MockedArmoniKClient();
+
+    var date = DateTime.UtcNow;
+    var filter = BuildOr(BuildAnd(BuildFilterDateTime("AcquiredAt",
+                                                      "==",
+                                                      date)));
+
+    var query = client.TasksService.AsQueryable()
+                      .Where(taskState => taskState.AcquiredAt == date);
+
+    // Execute the query
+    var result = query.AsAsyncEnumerable()
+                      .ToListAsync();
+
+    var taskQueryProvider = (TaskSummaryQueryProvider)((ArmoniKQueryable<TaskSummary>)query).Provider;
+    Assert.That(taskQueryProvider.QueryExecution!.PaginationInstance,
+                Is.EqualTo(BuildTaskPagination(filter)));
+  }
+
+  [Test]
+  public void FetchedAtFilterEqual()
+  {
+    var client = new MockedArmoniKClient();
+
+    var date = DateTime.UtcNow;
+    var filter = BuildOr(BuildAnd(BuildFilterDateTime("FetchedAt",
+                                                      "==",
+                                                      date)));
+
+    var query = client.TasksService.AsQueryable()
+                      .Where(taskState => taskState.FetchedAt == date);
+
+    // Execute the query
+    var result = query.AsAsyncEnumerable()
+                      .ToListAsync();
+
+    var taskQueryProvider = (TaskSummaryQueryProvider)((ArmoniKQueryable<TaskSummary>)query).Provider;
+    Assert.That(taskQueryProvider.QueryExecution!.PaginationInstance,
+                Is.EqualTo(BuildTaskPagination(filter)));
+  }
+
+  [Test]
+  public void ProcessedAtFilterEqual()
+  {
+    var client = new MockedArmoniKClient();
+
+    var date = DateTime.UtcNow;
+    var filter = BuildOr(BuildAnd(BuildFilterDateTime("ProcessedAt",
+                                                      "==",
+                                                      date)));
+
+    var query = client.TasksService.AsQueryable()
+                      .Where(taskState => taskState.ProcessedAt == date);
+
+    // Execute the query
+    var result = query.AsAsyncEnumerable()
+                      .ToListAsync();
+
+    var taskQueryProvider = (TaskSummaryQueryProvider)((ArmoniKQueryable<TaskSummary>)query).Provider;
+    Assert.That(taskQueryProvider.QueryExecution!.PaginationInstance,
+                Is.EqualTo(BuildTaskPagination(filter)));
+  }
+
+  [Test]
+  public void PodTtlFilterEqual()
+  {
+    var client = new MockedArmoniKClient();
+
+    var date = DateTime.UtcNow;
+    var filter = BuildOr(BuildAnd(BuildFilterDateTime("PodTTL",
+                                                      "==",
+                                                      date)));
+
+    var query = client.TasksService.AsQueryable()
+                      .Where(taskState => taskState.PodTTL == date);
+
+    // Execute the query
+    var result = query.AsAsyncEnumerable()
+                      .ToListAsync();
+
+    var taskQueryProvider = (TaskSummaryQueryProvider)((ArmoniKQueryable<TaskSummary>)query).Provider;
+    Assert.That(taskQueryProvider.QueryExecution!.PaginationInstance,
+                Is.EqualTo(BuildTaskPagination(filter)));
+  }
+
+  [Test]
+  public void CreationToEndFilterEqual()
+  {
+    var client = new MockedArmoniKClient();
+
+    var duration = TimeSpan.FromMinutes(30);
+    var filter = BuildOr(BuildAnd(BuildFilterDuration("CreationToEnd",
+                                                      "==",
+                                                      duration)));
+
+    var query = client.TasksService.AsQueryable()
+                      .Where(taskState => taskState.CreationToEnd == duration);
+
+    // Execute the query
+    var result = query.AsAsyncEnumerable()
+                      .ToListAsync();
+
+    var taskQueryProvider = (TaskSummaryQueryProvider)((ArmoniKQueryable<TaskSummary>)query).Provider;
+    Assert.That(taskQueryProvider.QueryExecution!.PaginationInstance,
+                Is.EqualTo(BuildTaskPagination(filter)));
+  }
+
+  [Test]
+  public void ProcessingToEndFilterEqual()
+  {
+    var client = new MockedArmoniKClient();
+
+    var duration = TimeSpan.FromMinutes(30);
+    var filter = BuildOr(BuildAnd(BuildFilterDuration("ProcessingToEnd",
+                                                      "==",
+                                                      duration)));
+
+    var query = client.TasksService.AsQueryable()
+                      .Where(taskState => taskState.ProcessingToEnd == duration);
+
+    // Execute the query
+    var result = query.AsAsyncEnumerable()
+                      .ToListAsync();
+
+    var taskQueryProvider = (TaskSummaryQueryProvider)((ArmoniKQueryable<TaskSummary>)query).Provider;
+    Assert.That(taskQueryProvider.QueryExecution!.PaginationInstance,
+                Is.EqualTo(BuildTaskPagination(filter)));
+  }
+
+  [Test]
+  public void ReceivedToEndFilterEqual()
+  {
+    var client = new MockedArmoniKClient();
+
+    var duration = TimeSpan.FromMinutes(30);
+    var filter = BuildOr(BuildAnd(BuildFilterDuration("ReceivedToEnd",
+                                                      "==",
+                                                      duration)));
+
+    var query = client.TasksService.AsQueryable()
+                      .Where(taskState => taskState.ReceivedToEnd == duration);
 
     // Execute the query
     var result = query.AsAsyncEnumerable()
@@ -191,6 +410,69 @@ public class FilterTaskTests : BaseTaskFilterTests
 
     var query = client.TasksService.AsQueryable()
                       .Where(taskState => taskState.Status == TaskStatus.Error);
+
+    // Execute the query
+    var result = query.AsAsyncEnumerable()
+                      .ToListAsync();
+
+    var taskQueryProvider = (TaskSummaryQueryProvider)((ArmoniKQueryable<TaskSummary>)query).Provider;
+    Assert.That(taskQueryProvider.QueryExecution!.PaginationInstance,
+                Is.EqualTo(BuildTaskPagination(filter)));
+  }
+
+  [Test]
+  public void OwnerPodIdFilterEqual()
+  {
+    var client = new MockedArmoniKClient();
+
+    var filter = BuildOr(BuildAnd(BuildFilterString("OwnerPodId",
+                                                    "==",
+                                                    "pod1")));
+
+    var query = client.TasksService.AsQueryable()
+                      .Where(taskState => taskState.OwnerPodId == "pod1");
+
+    // Execute the query
+    var result = query.AsAsyncEnumerable()
+                      .ToListAsync();
+
+    var taskQueryProvider = (TaskSummaryQueryProvider)((ArmoniKQueryable<TaskSummary>)query).Provider;
+    Assert.That(taskQueryProvider.QueryExecution!.PaginationInstance,
+                Is.EqualTo(BuildTaskPagination(filter)));
+  }
+
+  [Test]
+  public void PodHostNameFilterEqual()
+  {
+    var client = new MockedArmoniKClient();
+
+    var filter = BuildOr(BuildAnd(BuildFilterString("PodHostName",
+                                                    "==",
+                                                    "myhost")));
+
+    var query = client.TasksService.AsQueryable()
+                      .Where(taskState => taskState.PodHostName == "myhost");
+
+    // Execute the query
+    var result = query.AsAsyncEnumerable()
+                      .ToListAsync();
+
+    var taskQueryProvider = (TaskSummaryQueryProvider)((ArmoniKQueryable<TaskSummary>)query).Provider;
+    Assert.That(taskQueryProvider.QueryExecution!.PaginationInstance,
+                Is.EqualTo(BuildTaskPagination(filter)));
+  }
+
+  [Test]
+  public void InitialTaskIdFilterEqual()
+  {
+    var client = new MockedArmoniKClient();
+
+    var filter = BuildOr(BuildAnd(BuildFilterString("InitialTaskId",
+                                                    "==",
+                                                    "initialTask")));
+
+    var query = client.TasksService.AsQueryable()
+                      .Where(taskState => taskState.InitialTaskId == "initialTask");
 
     // Execute the query
     var result = query.AsAsyncEnumerable()

--- a/Tests/Services/TasksServiceTests.cs
+++ b/Tests/Services/TasksServiceTests.cs
@@ -16,6 +16,7 @@
 
 using System.Text;
 
+using ArmoniK.Api.gRPC.V1;
 using ArmoniK.Api.gRPC.V1.Tasks;
 using ArmoniK.Extensions.CSharp.Client.Common.Domain.Blob;
 using ArmoniK.Extensions.CSharp.Client.Common.Domain.Session;
@@ -423,19 +424,21 @@ public class TasksServiceTests
                          {
                            new TaskSummary
                            {
-                             Id        = "taskId1",
-                             Status    = (V1_TaskStatus)TaskStatus.Completed,
-                             CreatedAt = Timestamp.FromDateTime(DateTime.UtcNow),
-                             StartedAt = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-5)),
-                             EndedAt   = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-1)),
+                             Id          = "taskId1",
+                             Status      = (V1_TaskStatus)TaskStatus.Completed,
+                             CreatedAt   = Timestamp.FromDateTime(DateTime.UtcNow),
+                             SubmittedAt = Timestamp.FromDateTime(DateTime.UtcNow),
+                             StartedAt   = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-5)),
+                             EndedAt     = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-1)),
                            },
                            new TaskSummary
                            {
-                             Id        = "taskId2",
-                             Status    = (V1_TaskStatus)TaskStatus.Cancelling,
-                             CreatedAt = Timestamp.FromDateTime(DateTime.UtcNow),
-                             StartedAt = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-10)),
-                             EndedAt   = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-5)),
+                             Id          = "taskId2",
+                             Status      = (V1_TaskStatus)TaskStatus.Cancelling,
+                             CreatedAt   = Timestamp.FromDateTime(DateTime.UtcNow),
+                             SubmittedAt = Timestamp.FromDateTime(DateTime.UtcNow),
+                             StartedAt   = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-10)),
+                             EndedAt     = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-5)),
                            },
                          },
                          Total = 2,
@@ -505,10 +508,15 @@ public class TasksServiceTests
                                   {
                                     "dependencyId1",
                                   },
-                                  CreatedAt = Timestamp.FromDateTime(DateTime.UtcNow),
-                                  StartedAt = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-5)),
-                                  EndedAt   = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-1)),
-                                  SessionId = "sessionId1",
+                                  CreatedAt   = Timestamp.FromDateTime(DateTime.UtcNow),
+                                  SubmittedAt = Timestamp.FromDateTime(DateTime.UtcNow),
+                                  StartedAt   = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-5)),
+                                  EndedAt     = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-1)),
+                                  SessionId   = "sessionId1",
+                                  Options = new TaskOptions
+                                            {
+                                              MaxDuration = Duration.FromTimeSpan(TimeSpan.FromMinutes(30)),
+                                            },
                                 },
                        };
 
@@ -551,11 +559,12 @@ public class TasksServiceTests
                          {
                            new TaskDetailed
                            {
-                             Id        = "taskId1",
-                             Status    = V1_TaskStatus.Completed,
-                             CreatedAt = Timestamp.FromDateTime(DateTime.UtcNow),
-                             StartedAt = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-5)),
-                             EndedAt   = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-1)),
+                             Id          = "taskId1",
+                             Status      = V1_TaskStatus.Completed,
+                             CreatedAt   = Timestamp.FromDateTime(DateTime.UtcNow),
+                             SubmittedAt = Timestamp.FromDateTime(DateTime.UtcNow),
+                             StartedAt   = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-5)),
+                             EndedAt     = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-1)),
                              ExpectedOutputIds =
                              {
                                "outputId1",
@@ -565,14 +574,19 @@ public class TasksServiceTests
                                "dependencyId1",
                              },
                              SessionId = "sessionId1",
+                             Options = new TaskOptions
+                                       {
+                                         MaxDuration = Duration.FromTimeSpan(TimeSpan.FromMinutes(30)),
+                                       },
                            },
                            new TaskDetailed
                            {
-                             Id        = "taskId2",
-                             Status    = V1_TaskStatus.Cancelling,
-                             CreatedAt = Timestamp.FromDateTime(DateTime.UtcNow),
-                             StartedAt = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-10)),
-                             EndedAt   = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-5)),
+                             Id          = "taskId2",
+                             Status      = V1_TaskStatus.Cancelling,
+                             CreatedAt   = Timestamp.FromDateTime(DateTime.UtcNow),
+                             SubmittedAt = Timestamp.FromDateTime(DateTime.UtcNow),
+                             StartedAt   = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-10)),
+                             EndedAt     = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-5)),
                              ExpectedOutputIds =
                              {
                                "outputId2",
@@ -582,6 +596,10 @@ public class TasksServiceTests
                                "dependencyId2",
                              },
                              SessionId = "sessionId1",
+                             Options = new TaskOptions
+                                       {
+                                         MaxDuration = Duration.FromTimeSpan(TimeSpan.FromMinutes(30)),
+                                       },
                            },
                          },
                          Total = 2,
@@ -644,23 +662,25 @@ public class TasksServiceTests
                            {
                              new TaskSummary
                              {
-                               Id        = "taskId1",
-                               Status    = V1_TaskStatus.Cancelled,
-                               CreatedAt = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-10)),
-                               StartedAt = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-5)),
-                               EndedAt   = Timestamp.FromDateTime(DateTime.UtcNow),
-                               SessionId = "sessionId1",
-                               PayloadId = "payloadId1",
+                               Id          = "taskId1",
+                               Status      = V1_TaskStatus.Cancelled,
+                               CreatedAt   = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-10)),
+                               SubmittedAt = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-10)),
+                               StartedAt   = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-5)),
+                               EndedAt     = Timestamp.FromDateTime(DateTime.UtcNow),
+                               SessionId   = "sessionId1",
+                               PayloadId   = "payloadId1",
                              },
                              new TaskSummary
                              {
-                               Id        = "taskId2",
-                               Status    = V1_TaskStatus.Cancelled,
-                               CreatedAt = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-8)),
-                               StartedAt = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-3)),
-                               EndedAt   = Timestamp.FromDateTime(DateTime.UtcNow),
-                               SessionId = "sessionId1",
-                               PayloadId = "payloadId2",
+                               Id          = "taskId2",
+                               Status      = V1_TaskStatus.Cancelled,
+                               CreatedAt   = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-8)),
+                               SubmittedAt = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-8)),
+                               StartedAt   = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-3)),
+                               EndedAt     = Timestamp.FromDateTime(DateTime.UtcNow),
+                               SessionId   = "sessionId1",
+                               PayloadId   = "payloadId2",
                              },
                            },
                          };


### PR DESCRIPTION
# Motivation

Add missing properties in TaskState and TaskSummary.

# Description

The protobuf messages TaskDetailed and TaskSummary have properties that have no counterpart in the corresponding SDK types (respectively TaskState and TaskSummary). This PR add these missing properties.

# Testing

Non regression tests passed.
Added new unit tests for the filtering on new properties.

# Impact

Conversion methods from protobuf types to SDK types.

# Additional Information

TaskState and TaskSummary new consume more memory.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
