### PR TITLE
fix: error 'invalid boolean expression' on filter expression

### DIFF
--- a/ArmoniK.Extensions.CSharp.Client/Queryable/WhereExpressionTreeVisitor.cs
+++ b/ArmoniK.Extensions.CSharp.Client/Queryable/WhereExpressionTreeVisitor.cs
@@ -767,13 +767,16 @@ internal abstract class WhereExpressionTreeVisitor<TField, TFilterOr, TFilterAnd
           {
             foreach (var rhsFilterAnd in GetRepeatedFilterAnd(rhsFilterOr))
             {
-              GetRepeatedFilterField(rhsFilterAnd).Add(lhsFilterField);
+              GetRepeatedFilterField(rhsFilterAnd)
+                .Add(lhsFilterField);
             }
+
             FilterStack.Push((rhsFilterOr, typeof(bool)));
           }
           else if (rhsFilter is TFilterAnd rhsFilterAnd)
           {
-            GetRepeatedFilterField(rhsFilterAnd).Add(lhsFilterField);
+            GetRepeatedFilterField(rhsFilterAnd)
+              .Add(lhsFilterField);
             FilterStack.Push((rhsFilterAnd, typeof(bool)));
           }
           else if (rhsFilter is TFilterField rhsFilterField)

--- a/ArmoniK.Extensions.CSharp.Client/Queryable/WhereExpressionTreeVisitor.cs
+++ b/ArmoniK.Extensions.CSharp.Client/Queryable/WhereExpressionTreeVisitor.cs
@@ -763,7 +763,20 @@ internal abstract class WhereExpressionTreeVisitor<TField, TFilterOr, TFilterAnd
         }
         else if (lhsFilter is TFilterField lhsFilterField)
         {
-          if (rhsFilter is TFilterField rhsFilterField)
+          if (rhsFilter is TFilterOr rhsFilterOr)
+          {
+            foreach (var rhsFilterAnd in GetRepeatedFilterAnd(rhsFilterOr))
+            {
+              GetRepeatedFilterField(rhsFilterAnd).Add(lhsFilterField);
+            }
+            FilterStack.Push((rhsFilterOr, typeof(bool)));
+          }
+          else if (rhsFilter is TFilterAnd rhsFilterAnd)
+          {
+            GetRepeatedFilterField(rhsFilterAnd).Add(lhsFilterField);
+            FilterStack.Push((rhsFilterAnd, typeof(bool)));
+          }
+          else if (rhsFilter is TFilterField rhsFilterField)
           {
             // <filter field> && <filter field>
             var andFilter = CreateFilterAnd(lhsFilterField,

--- a/Tests/Queryable/BooleanExpressionFilterBlobTests.cs
+++ b/Tests/Queryable/BooleanExpressionFilterBlobTests.cs
@@ -632,6 +632,67 @@ public class BooleanExpressionFilterBlobTests : BaseBlobFilterTests
                 Is.EqualTo(BuildBlobPagination(filter)));
   }
 
+  // <filter field> && <or expression>
+  [Test]
+  public void AndExpressionOfFilterAndOr()
+  {
+    var client = new MockedArmoniKClient();
+
+    var filter = BuildOr(BuildAnd(BuildFilterString("BlobId",
+                                                    "==",
+                                                    "blob1"),
+                                  BuildFilterString("BlobName",
+                                                    "==",
+                                                    "myBlob")),
+                         BuildAnd(BuildFilterString("BlobId",
+                                                    "==",
+                                                    "blob2"),
+                                  BuildFilterString("BlobName",
+                                                    "==",
+                                                    "myBlob")));
+
+    // Build the query that get all blobs from session "session1"
+    var query = client.BlobService.AsQueryable()
+                      .Where(blobState => blobState.BlobName == "myBlob" && (blobState.BlobId == "blob1" || blobState.BlobId == "blob2"));
+
+    // Execute the query
+    var result = query.AsAsyncEnumerable()
+                      .ToListAsync();
+
+    var blobQueryProvider = (BlobStateQueryProvider)((ArmoniKQueryable<BlobState>)query).Provider;
+    Assert.That(blobQueryProvider.QueryExecution!.PaginationInstance,
+                Is.EqualTo(BuildBlobPagination(filter)));
+  }
+
+  // <filter field> && <and expression>
+  [Test]
+  public void AndExpressionOfFilterAndAnd()
+  {
+    var client = new MockedArmoniKClient();
+
+    var filter = BuildOr(BuildAnd(BuildFilterString("BlobId",
+                                                    "==",
+                                                    "blob1"),
+                                  BuildFilterString("BlobId",
+                                                    "==",
+                                                    "blob2"),
+                                  BuildFilterString("BlobName",
+                                                    "==",
+                                                    "myBlob")));
+
+    // Build the query that get all blobs from session "session1"
+    var query = client.BlobService.AsQueryable()
+                      .Where(blobState => blobState.BlobName == "myBlob" && (blobState.BlobId == "blob1" && blobState.BlobId == "blob2"));
+
+    // Execute the query
+    var result = query.AsAsyncEnumerable()
+                      .ToListAsync();
+
+    var blobQueryProvider = (BlobStateQueryProvider)((ArmoniKQueryable<BlobState>)query).Provider;
+    Assert.That(blobQueryProvider.QueryExecution!.PaginationInstance,
+                Is.EqualTo(BuildBlobPagination(filter)));
+  }
+
   // <and expression> && <or expression>
   [Test]
   public void AndExpressionOfAndAndOr()

--- a/Tests/Queryable/BooleanExpressionFilterBlobTests.cs
+++ b/Tests/Queryable/BooleanExpressionFilterBlobTests.cs
@@ -651,6 +651,7 @@ public class BooleanExpressionFilterBlobTests : BaseBlobFilterTests
                                                     "==",
                                                     "myBlob")));
 
+
     // Build the query that get all blobs from session "session1"
     var query = client.BlobService.AsQueryable()
                       .Where(blobState => blobState.BlobName == "myBlob" && (blobState.BlobId == "blob1" || blobState.BlobId == "blob2"));
@@ -680,9 +681,45 @@ public class BooleanExpressionFilterBlobTests : BaseBlobFilterTests
                                                     "==",
                                                     "myBlob")));
 
+    // Let's build manually the following expression tree because Resharper simplify the expression by removing parentheses
+    // blobState => blobState.BlobName == "myBlob" && (blobState.BlobId == "blob1" && blobState.BlobId == "blob2")
+    // Parameter: blobState =>
+    var param = Expression.Parameter(typeof(BlobState),
+                                     "blobState");
+
+    // Access to properties
+    var blobIdProperty = Expression.Property(param,
+                                             nameof(BlobState.BlobId));
+    var blobNameProperty = Expression.Property(param,
+                                               nameof(BlobState.BlobName));
+
+    // Expression "blobState.BlobName == "myBlob""
+    var myBlob = Expression.Equal(blobNameProperty,
+                                  Expression.Constant("myBlob"));
+
+    // Expression "blobState.BlobId == "blob1""
+    var blob1 = Expression.Equal(blobIdProperty,
+                                 Expression.Constant("blob1"));
+
+    // Expression "blobState.BlobId == "blob2""
+    var blob2 = Expression.Equal(blobIdProperty,
+                                 Expression.Constant("blob2"));
+
+    // (blob1 && blob2)
+    var and1 = Expression.AndAlso(blob1,
+                                  blob2);
+
+    // (myBlob && and1)
+    var finalAnd = Expression.AndAlso(myBlob,
+                                      and1);
+
+    // Full lambda : blobState => ...
+    var lambda = Expression.Lambda<Func<BlobState, bool>>(finalAnd,
+                                                          param);
+
     // Build the query that get all blobs from session "session1"
     var query = client.BlobService.AsQueryable()
-                      .Where(blobState => blobState.BlobName == "myBlob" && blobState.BlobId == "blob1" && blobState.BlobId == "blob2");
+                      .Where(lambda);
 
     // Execute the query
     var result = query.AsAsyncEnumerable()

--- a/Tests/Queryable/BooleanExpressionFilterBlobTests.cs
+++ b/Tests/Queryable/BooleanExpressionFilterBlobTests.cs
@@ -682,7 +682,7 @@ public class BooleanExpressionFilterBlobTests : BaseBlobFilterTests
 
     // Build the query that get all blobs from session "session1"
     var query = client.BlobService.AsQueryable()
-                      .Where(blobState => blobState.BlobName == "myBlob" && (blobState.BlobId == "blob1" && blobState.BlobId == "blob2"));
+                      .Where(blobState => blobState.BlobName == "myBlob" && blobState.BlobId == "blob1" && blobState.BlobId == "blob2");
 
     // Execute the query
     var result = query.AsAsyncEnumerable()


### PR DESCRIPTION
# Motivation

Fix an error 'invalid boolean expression' on filter expression.

# Description

Add missing handling of expressions of the of the following forms:
- filter field && or expression
- filter field && and expression

Checked that every valid form is handled and tested.

# Testing

Added unit tests related to the error.
Passed non regression tests.

# Impact

Filtering.

# Additional Information

None.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
