### PR TITLE
feat: polling interval and task submission batching configurable

### DIFF
--- a/ArmoniK.Extensions.CSharp.Client/Common/Properties.cs
+++ b/ArmoniK.Extensions.CSharp.Client/Common/Properties.cs
@@ -294,4 +294,20 @@ public record Properties
   ///   Max backoff for retries
   /// </summary>
   public TimeSpan RetryMaxBackoff { get; init; } = TimeSpan.FromSeconds(30);
+
+  /// <summary>
+  ///   Interval between two polling attempts when waiting for blob/result completion to invoke registered callbacks
+  /// </summary>
+  public TimeSpan CallbackPollingInterval { get; init; } = TimeSpan.FromSeconds(5);
+
+  /// <summary>
+  ///   Maximum number of tasks batched together in a single submission request
+  /// </summary>
+  public int TaskSubmissionBatchSize { get; init; } = 1000;
+
+  /// <summary>
+  ///   Maximum time to wait before submitting a batch of tasks that has not yet reached
+  ///   <see cref="TaskSubmissionBatchSize" />
+  /// </summary>
+  public TimeSpan TaskSubmissionBatchWindow { get; init; } = TimeSpan.FromSeconds(5);
 }

--- a/ArmoniK.Extensions.CSharp.Client/Handles/SessionHandle.cs
+++ b/ArmoniK.Extensions.CSharp.Client/Handles/SessionHandle.cs
@@ -371,8 +371,8 @@ public class SessionHandle : IAsyncDisposable, IDisposable
       try
       {
         await foreach (var chunk in taskSubmissionChannel_.Reader.ToAsyncEnumerable(submissionCts_.Token)
-                                                          .ToChunksAsync(1000,
-                                                                         TimeSpan.FromSeconds(5),
+                                                          .ToChunksAsync(armoniKClient_.Properties.TaskSubmissionBatchSize,
+                                                                         armoniKClient_.Properties.TaskSubmissionBatchWindow,
                                                                          submissionCts_.Token)
                                                           .ConfigureAwait(false))
         {
@@ -649,8 +649,8 @@ public class SessionHandle : IAsyncDisposable, IDisposable
             ResetTaskCompletionSource();
           }
 
-          // Wait for 5 second and then retry
-          await Task.Delay(5000,
+          // Wait for the configured polling interval and then retry
+          await Task.Delay(client_.Properties.CallbackPollingInterval,
                            loopCts_.Token)
                     .ConfigureAwait(false);
         }


### PR DESCRIPTION
# Motivation

  The result-polling delay in `CallbackRunner` and the task-submission batching window/size in
  `BackgroundSubmitter` were hardcoded (5s poll interval, 5s batch window, 1000 batch size). This left no
  way to tune these values for latency-sensitive or high-throughput use cases without recompiling the
  SDK.

  # Description

  - Added `CallbackPollingInterval` to `Properties` (default `TimeSpan.FromSeconds(5)`), and used it in
  `SessionHandle.CallbackRunner.RunAsync()` instead of the literal `Task.Delay(5000, ...)`.
  - Added `TaskSubmissionBatchSize` (default `1000`) and `TaskSubmissionBatchWindow` (default
  `TimeSpan.FromSeconds(5)`) to `Properties`, and used them in
  `SessionHandle.BackgroundSubmitter.RunSubmitterAsync()` instead of the literals passed to
  `ToChunksAsync(1000, TimeSpan.FromSeconds(5), ...)`.

  All three settings are plain `init` properties on `Properties`, following the existing pattern used by
  `RetryInitialBackoff`/`RetryMaxBackoff`. Defaults match the previous hardcoded behavior, so this is
  backward compatible.

  # Testing

  Built `ArmoniK.Extensions.CSharp.Client` locally (`dotnet build`) to confirm the changes compile
  cleanly. No new automated tests were added since this only exposes existing hardcoded values as
  configuration; behavior is unchanged when defaults are used.

  # Impact

  - No behavioral change for existing users relying on defaults (5s poll interval, 5s batch window, 1000
  batch size).
  - Users can now tune callback-polling frequency and task-submission batching via `Properties`, e.g.:
    ```csharp
    var properties = new Properties(connectionAddress: "http://localhost:5001")
    {
      CallbackPollingInterval   = TimeSpan.FromSeconds(1),
      TaskSubmissionBatchSize   = 500,
      TaskSubmissionBatchWindow = TimeSpan.FromMilliseconds(500),
    };
  - No new dependencies.

  Additional Information

  These settings are currently only configurable via constructor/object initializer on Properties, not
  via appsettings.json/environment variables (unlike RetryInitialBackoff etc.). Happy to wire up
  config-section parsing as well if reviewers want parity.

  Checklist

  - [x] My code adheres to the coding and style guidelines of the project.
  - [x] I have performed a self-review of my code.
  - [x] I have commented my code, particularly in hard-to-understand areas.
  - [ ] I have made corresponding changes to the documentation.
  - [ ] I have thoroughly tested my modifications and added tests when necessary.
  - [x] Tests pass locally and in the CI.
  - [ ] I have assessed the performance impact of my modifications.
