### PR TITLE
feat: replace BlobDefinition.BlobHandle property with GetBlobHandleAsync()

### DIFF
--- a/ArmoniK.Extensions.CSharp.Client/Common/Domain/Blob/BlobDefinition.cs
+++ b/ArmoniK.Extensions.CSharp.Client/Common/Domain/Blob/BlobDefinition.cs
@@ -32,9 +32,7 @@ namespace ArmoniK.Extensions.CSharp.Client.Common.Domain.Blob;
 /// </summary>
 public class BlobDefinition
 {
-  private readonly FileInfo?             file_;
-  private          long                  dataSize_;
-  private          ReadOnlyMemory<byte>? data_;
+  private readonly FileInfo? file_;
 
   /// <summary>
   ///   Promise of the BlobHandle once the blob has been registered.
@@ -42,7 +40,9 @@ public class BlobDefinition
   /// </summary>
   private volatile TaskCompletionSource<BlobHandle>? blobHandleSource_ = new();
 
-  private BlobHandle? blobHandle_;
+  private BlobHandle?           blobHandle_;
+  private long                  dataSize_;
+  private ReadOnlyMemory<byte>? data_;
 
   /// <summary>
   ///   Creation of a blob definition with known data
@@ -132,6 +132,13 @@ public class BlobDefinition
   }
 
   /// <summary>
+  ///   Indicates whether the blob may be a pipe,
+  ///   when true it is not necessarily a pipe, when false we're sure it's not a pipe.
+  /// </summary>
+  internal bool MayBeAPipe
+    => dataSize_ == 0 && file_ != null;
+
+  /// <summary>
   ///   Get the blob handle once the blob has been registered.
   ///   This awaits until the blob has actually been created, which may happen asynchronously
   ///   (e.g. when task submission batching is enabled).
@@ -167,13 +174,6 @@ public class BlobDefinition
       return handle;
     }
   }
-
-  /// <summary>
-  ///   Indicates whether the blob may be a pipe,
-  ///   when true it is not necessarily a pipe, when false we're sure it's not a pipe.
-  /// </summary>
-  internal bool MayBeAPipe
-    => dataSize_ == 0 && file_ != null;
 
   /// <summary>
   ///   Fetch the last state the file, whenever the blob comes from a file.

--- a/ArmoniK.Extensions.CSharp.Client/Common/Domain/Blob/BlobDefinition.cs
+++ b/ArmoniK.Extensions.CSharp.Client/Common/Domain/Blob/BlobDefinition.cs
@@ -20,6 +20,7 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 
 using ArmoniK.Extensions.CSharp.Client.Exceptions;
 using ArmoniK.Extensions.CSharp.Client.Handles;
@@ -34,6 +35,14 @@ public class BlobDefinition
   private readonly FileInfo?             file_;
   private          long                  dataSize_;
   private          ReadOnlyMemory<byte>? data_;
+
+  /// <summary>
+  ///   Promise of the BlobHandle once the blob has been registered.
+  ///   It needs to be volatile as we need it to play the role of a barrier in GetBlobHandleAsync().
+  /// </summary>
+  private volatile TaskCompletionSource<BlobHandle>? blobHandleSource_ = new();
+
+  private BlobHandle? blobHandle_;
 
   /// <summary>
   ///   Creation of a blob definition with known data
@@ -109,7 +118,55 @@ public class BlobDefinition
   /// <summary>
   ///   Handle once the blob has been registered
   /// </summary>
-  public BlobHandle? BlobHandle { get; internal set; }
+  internal BlobHandle? BlobHandle
+  {
+    get => blobHandle_;
+    set
+    {
+      blobHandle_ = value;
+      if (value != null)
+      {
+        blobHandleSource_?.TrySetResult(value);
+      }
+    }
+  }
+
+  /// <summary>
+  ///   Get the blob handle once the blob has been registered.
+  ///   This awaits until the blob has actually been created, which may happen asynchronously
+  ///   (e.g. when task submission batching is enabled).
+  /// </summary>
+  /// <returns>A task representing the asynchronous operation. The task result contains the BlobHandle instance.</returns>
+  public ValueTask<BlobHandle> GetBlobHandleAsync()
+  {
+    var blobHandle = blobHandle_;
+    if (blobHandle is not null)
+    {
+      return new ValueTask<BlobHandle>(blobHandle);
+    }
+
+    return Core();
+
+    async ValueTask<BlobHandle> Core()
+    {
+      // volatile read of blobHandleSource_ here has acquire semantics and with the combination
+      // of the volatile write of blobHandleSource_ below, it ensures that if we see a null value for blobHandleSource_,
+      // we are guaranteed to see a non-null value for blobHandle_.
+      var tcs = blobHandleSource_;
+      if (tcs is null)
+      {
+        return blobHandle_!;
+      }
+
+      var handle = await tcs.Task.ConfigureAwait(false);
+      blobHandle_ = handle;
+      // volatile write of blobHandleSource_ here has release semantics (allows other threads to see the effects of preceding operations).
+      // This prevent the compiler to do some operation reordering, then we are sure blobHandle_ has actually been assigned when we reach that point
+      // therefore if a thread can see a null blobHandleSource_, it is guaranteed to see a non-null blobHandle_.
+      blobHandleSource_ = null;
+      return handle;
+    }
+  }
 
   /// <summary>
   ///   Indicates whether the blob may be a pipe,

--- a/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/CheckBlobCreationResponseOrderClient.cs
+++ b/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/CheckBlobCreationResponseOrderClient.cs
@@ -58,7 +58,9 @@ internal class CheckBlobCreationResponseOrderClient : ClientBase
 
     foreach (var blob in taskDefinition.Outputs.Values)
     {
-      var name = blob.BlobHandle!.BlobInfo.BlobName;
+      var blobHandle = await blob.GetBlobHandleAsync()
+                                 .ConfigureAwait(false);
+      var name = blobHandle.BlobInfo.BlobName;
       var data = ((Callback)blob.CallBack!).Result;
       Assert.That(data,
                   Is.EqualTo(name));

--- a/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/PriorityClient.cs
+++ b/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/PriorityClient.cs
@@ -85,6 +85,7 @@ public class PriorityClient : ClientBase
                                    .ConfigureAwait(false);
       allResults.Add(blobHandle.BlobInfo);
     }
+
     await Client!.EventsService.WaitForBlobsAsync(SessionHandle!,
                                                   allResults,
                                                   CancellationToken.None)

--- a/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/PriorityClient.cs
+++ b/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/PriorityClient.cs
@@ -19,6 +19,7 @@ using System.Text;
 using ArmoniK.Extensions.CSharp.Client.Common.Domain.Blob;
 using ArmoniK.Extensions.CSharp.Client.Common.Domain.Task;
 using ArmoniK.Extensions.CSharp.Client.Handles;
+using ArmoniK.Extensions.CSharp.Common.Common.Domain.Blob;
 
 namespace ArmoniK.EndToEndTests.Client.Tests;
 
@@ -77,8 +78,13 @@ public class PriorityClient : ClientBase
       taskDefinitions.Clear();
     }
 
-    var allResults = allTasks.SelectMany(t => t.Outputs.Values.Select(o => o.BlobHandle!.BlobInfo))
-                             .ToList();
+    var allResults = new List<BlobInfo>();
+    foreach (var output in allTasks.SelectMany(t => t.Outputs.Values))
+    {
+      var blobHandle = await output.GetBlobHandleAsync()
+                                   .ConfigureAwait(false);
+      allResults.Add(blobHandle.BlobInfo);
+    }
     await Client!.EventsService.WaitForBlobsAsync(SessionHandle!,
                                                   allResults,
                                                   CancellationToken.None)

--- a/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/TaskSdkClient.cs
+++ b/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/TaskSdkClient.cs
@@ -59,11 +59,11 @@ public class TaskSdkClient : ClientBase
     var outputName = taskDefinition.Outputs.Single()
                                    .Key;
     var outputBlobHandle = await taskDefinition.Outputs.Single()
-                                                .Value.GetBlobHandleAsync()
-                                                .ConfigureAwait(false);
-    var inputBlobHandle = await taskDefinition.InputDefinitions.Single()
                                                .Value.GetBlobHandleAsync()
                                                .ConfigureAwait(false);
+    var inputBlobHandle = await taskDefinition.InputDefinitions.Single()
+                                              .Value.GetBlobHandleAsync()
+                                              .ConfigureAwait(false);
     if (outputName == "outputString")
     {
       resultString = Encoding.UTF8.GetString(callback.Result);

--- a/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/TaskSdkClient.cs
+++ b/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/TaskSdkClient.cs
@@ -58,10 +58,12 @@ public class TaskSdkClient : ClientBase
     var resultString = "";
     var outputName = taskDefinition.Outputs.Single()
                                    .Key;
-    var outputBlobHandle = taskDefinition.Outputs.Single()
-                                         .Value.BlobHandle;
-    var inputBlobHandle = taskDefinition.InputDefinitions.Single()
-                                        .Value.BlobHandle;
+    var outputBlobHandle = await taskDefinition.Outputs.Single()
+                                                .Value.GetBlobHandleAsync()
+                                                .ConfigureAwait(false);
+    var inputBlobHandle = await taskDefinition.InputDefinitions.Single()
+                                               .Value.GetBlobHandleAsync()
+                                               .ConfigureAwait(false);
     if (outputName == "outputString")
     {
       resultString = Encoding.UTF8.GetString(callback.Result);

--- a/UsageExample/Program.cs
+++ b/UsageExample/Program.cs
@@ -111,8 +111,9 @@ internal class Program
     var taskInfo = await taskHandle.GetTaskInfosAsync()
                                    .ConfigureAwait(false);
 
-    BlobInfo resultBlobInfo = task.Outputs.Values.First()
-                                  .BlobHandle!;
+    BlobInfo resultBlobInfo = await task.Outputs.Values.First()
+                                        .GetBlobHandleAsync()
+                                        .ConfigureAwait(false);
     logger.LogInformation("resultId: {ResultId}",
                           resultBlobInfo.BlobId);
     logger.LogInformation("taskId: {TaskId}",


### PR DESCRIPTION
# Motivation

`BlobDefinition.BlobHandle` was a plain nullable property, set once the underlying blob had actually
been created. Since task submission can be batched (configurable polling interval/batching), that
creation can happen asynchronously in the background after `SessionHandle.Submit(...)` returns, so
reading `.BlobHandle!` right after submission relied on implicit ordering with no compiler-enforced
guarantee that it had been set yet.

# Description

Replaced the public `BlobDefinition.BlobHandle` property with a `GetBlobHandleAsync()` method,
mirroring the existing `TaskHandle.GetTaskInfosAsync()` pattern: it returns immediately if the handle
is already known, otherwise awaits a `TaskCompletionSource<BlobHandle>` that gets resolved once the
blob is actually created, using the same `volatile` barrier technique as `TaskHandle`.

The property itself is now `internal` (kept for the existing synchronous bookkeeping in
`BlobService`/`TaskDefinition`, and still reachable from `Tests` via `InternalsVisibleTo`). External
consumers now go through `GetBlobHandleAsync()`.

# Testing

- Updated `UsageExample/Program.cs` and the `End2EndTests` (`TaskSdkClient`, `PriorityClient`,
  `CheckBlobCreationResponseOrderClient`) to use `await blobDefinition.GetBlobHandleAsync()` instead
  of the removed public property.

# Impact

`BlobDefinition.BlobHandle` becoming `internal` is a breaking change for any external code (outside
this repo) reading that property directly — it must switch to `await GetBlobHandleAsync()`.

# Additional Information

None.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the
- [ ] I have assessed the performanc