### PR TITLE
feat: make client-side BlobHandle async-native

### DIFF
--- a/ArmoniK.Extensions.CSharp.Client/Common/Domain/Blob/BlobDefinition.cs
+++ b/ArmoniK.Extensions.CSharp.Client/Common/Domain/Blob/BlobDefinition.cs
@@ -32,6 +32,7 @@ namespace ArmoniK.Extensions.CSharp.Client.Common.Domain.Blob;
 public class BlobDefinition
 {
   private readonly FileInfo?             file_;
+  private          BlobHandle?           blobHandle_;
   private          long                  dataSize_;
   private          ReadOnlyMemory<byte>? data_;
 
@@ -107,9 +108,11 @@ public class BlobDefinition
   public bool HasData { get; init; }
 
   /// <summary>
-  ///   Handle once the blob has been registered
+  ///   Handle once the blob has been registered. It is created (in a pending state) as soon as the blob definition
+  ///   is attached to a submission, and resolved once the blob is actually created server-side; null before that.
   /// </summary>
-  public BlobHandle? BlobHandle { get; internal set; }
+  public BlobHandle? BlobHandle
+    => blobHandle_;
 
   /// <summary>
   ///   Indicates whether the blob may be a pipe,
@@ -117,6 +120,27 @@ public class BlobDefinition
   /// </summary>
   internal bool MayBeAPipe
     => dataSize_ == 0 && file_ != null;
+
+  /// <summary>
+  ///   Ensures a <see cref="Handles.BlobHandle" /> exists for this definition, creating a pending one if needed.
+  ///   Idempotent and safe to call concurrently: only one <see cref="Handles.BlobHandle" /> instance ever wins.
+  /// </summary>
+  /// <param name="armoniKClient">The ArmoniK client to associate the pending handle with.</param>
+  /// <returns>The existing or newly created <see cref="Handles.BlobHandle" />.</returns>
+  internal BlobHandle EnsureBlobHandle(ArmoniKClient armoniKClient)
+  {
+    var existing = blobHandle_;
+    if (existing != null)
+    {
+      return existing;
+    }
+
+    var pending = new BlobHandle(armoniKClient);
+    var winner = Interlocked.CompareExchange(ref blobHandle_,
+                                             pending,
+                                             null);
+    return winner ?? pending;
+  }
 
   /// <summary>
   ///   Fetch the last state the file, whenever the blob comes from a file.
@@ -289,15 +313,21 @@ public class BlobDefinition
   }
 
   /// <summary>
-  ///   Creates a BlobDefinition from a blob handle
+  ///   Creates a BlobDefinition from a blob handle. The handle must already be resolved (i.e. reference an
+  ///   existing blob), since the blob's name is required immediately.
   /// </summary>
   /// <param name="handle">The blob handle</param>
   /// <returns>The newly created blob definition</returns>
+  /// <exception cref="ArmoniKSdkException">Thrown when the handle is not resolved yet.</exception>
   public static BlobDefinition FromBlobHandle(BlobHandle handle)
-    => new(handle.BlobInfo.BlobName)
-       {
-         BlobHandle = handle,
-       };
+  {
+    var blobInfo = handle.ResolvedBlobInfoOrNull ?? throw new ArmoniKSdkException("The blob handle must be resolved before it can be used to create a BlobDefinition.");
+    var definition = new BlobDefinition(blobInfo.BlobName)
+                     {
+                       blobHandle_ = handle,
+                     };
+    return definition;
+  }
 
   /// <summary>
   ///   Creates a BlobDefinition from a file

--- a/ArmoniK.Extensions.CSharp.Client/Common/Domain/Task/TaskDefinition.cs
+++ b/ArmoniK.Extensions.CSharp.Client/Common/Domain/Task/TaskDefinition.cs
@@ -91,8 +91,9 @@ public class TaskDefinition
   {
     if (blobDeclaration.BlobHandle != null)
     {
+      var resolvedBlobInfo = blobDeclaration.BlobHandle.ResolvedBlobInfoOrNull;
       throw new
-        ArmoniKSdkException($"The task cannot take as output the already created blob '{blobDeclaration.BlobHandle.BlobInfo.BlobName}' with with BlobId '{blobDeclaration.BlobHandle.BlobInfo.BlobId}'");
+        ArmoniKSdkException($"The task cannot take as output the already created blob '{resolvedBlobInfo?.BlobName}' with with BlobId '{resolvedBlobInfo?.BlobId}'");
     }
 
     Outputs.Add(outputName,

--- a/ArmoniK.Extensions.CSharp.Client/Handles/BlobHandle.cs
+++ b/ArmoniK.Extensions.CSharp.Client/Handles/BlobHandle.cs
@@ -36,13 +36,19 @@ public class BlobHandle
   public readonly ArmoniKClient ArmoniKClient;
 
   /// <summary>
-  ///   The blob containing name, session ID, and blob ID.
+  ///   Promise of the BlobInfo once the blob has actually been created.
+  ///   It needs to be volatile as we need it to play the role of a barrier in GetBlobInfoAsync().
   /// </summary>
-  public readonly BlobInfo BlobInfo;
+  private volatile TaskCompletionSource<BlobInfo>? blobInfoSource_;
+
+  /// <summary>
+  ///   The blob info once it is known.
+  /// </summary>
+  private BlobInfo? blobInfo_;
 
   /// <summary>
   ///   Initializes a new instance of the <see cref="BlobHandle" /> class with specified blob information and an ArmoniK
-  ///   client.
+  ///   client. The handle is already resolved.
   /// </summary>
   /// <param name="blobInfo">The information about the blob.</param>
   /// <param name="armoniKClient">The ArmoniK client used for performing blob operations.</param>
@@ -50,13 +56,13 @@ public class BlobHandle
                     ArmoniKClient armoniKClient)
 
   {
-    BlobInfo      = blobInfo      ?? throw new ArgumentNullException(nameof(blobInfo));
+    blobInfo_     = blobInfo      ?? throw new ArgumentNullException(nameof(blobInfo));
     ArmoniKClient = armoniKClient ?? throw new ArgumentNullException(nameof(armoniKClient));
   }
 
   /// <summary>
   ///   Initializes a new instance of the <see cref="BlobHandle" /> class with specified blob details and an ArmoniK
-  ///   client.
+  ///   client. The handle is already resolved.
   /// </summary>
   /// <param name="blobName">The name of the blob.</param>
   /// <param name="blobId">The identifier of the blob.</param>
@@ -67,25 +73,37 @@ public class BlobHandle
                     string        sessionId,
                     ArmoniKClient armoniKClient)
   {
-    BlobInfo = new BlobInfo
-               {
-                 BlobId    = blobId,
-                 BlobName  = blobName,
-                 SessionId = sessionId,
-               };
+    blobInfo_ = new BlobInfo
+                {
+                  BlobId    = blobId,
+                  BlobName  = blobName,
+                  SessionId = sessionId,
+                };
     ArmoniKClient = armoniKClient ?? throw new ArgumentNullException(nameof(armoniKClient));
   }
 
   /// <summary>
-  ///   Implicit conversion operator from BlobHandle to BlobInfo.
-  ///   Allows BlobHandle to be used wherever BlobInfo is expected.
+  ///   Initializes a new instance of the <see cref="BlobHandle" /> class that is not resolved yet.
+  ///   Its <see cref="BlobInfo" /> will be known once <see cref="BlobInfoSource" /> is completed.
   /// </summary>
-  /// <param name="blobHandle">The BlobHandle to convert.</param>
-  /// <returns>The BlobInfo contained within the BlobHandle.</returns>
-  /// <exception cref="ArgumentNullException">Thrown when blobHandle is null.</exception>
-  public static implicit operator BlobInfo(BlobHandle blobHandle)
-    => blobHandle?.BlobInfo ?? throw new ArgumentNullException(nameof(blobHandle));
+  /// <param name="armoniKClient">The ArmoniK client used for performing blob operations.</param>
+  internal BlobHandle(ArmoniKClient armoniKClient)
+  {
+    ArmoniKClient   = armoniKClient ?? throw new ArgumentNullException(nameof(armoniKClient));
+    blobInfoSource_ = new TaskCompletionSource<BlobInfo>(TaskCreationOptions.RunContinuationsAsynchronously);
+  }
 
+  /// <summary>
+  ///   The TaskCompletionSource valued once the blob has actually been created, null if the handle is already resolved.
+  /// </summary>
+  internal TaskCompletionSource<BlobInfo>? BlobInfoSource
+    => blobInfoSource_;
+
+  /// <summary>
+  ///   Whenever the handle is already resolved, returns its BlobInfo, null otherwise.
+  /// </summary>
+  internal BlobInfo? ResolvedBlobInfoOrNull
+    => blobInfo_;
 
   /// <summary>
   ///   Creates a BlobHandle from BlobInfo and ArmoniKClient.
@@ -100,14 +118,53 @@ public class BlobHandle
            armoniKClient ?? throw new ArgumentNullException(nameof(armoniKClient)));
 
   /// <summary>
+  ///   Asynchronously retrieves the BlobInfo of the blob, waiting for the blob to be created if necessary.
+  /// </summary>
+  /// <returns>A task representing the asynchronous operation. The task result contains the BlobInfo instance.</returns>
+  public ValueTask<BlobInfo> GetBlobInfoAsync()
+  {
+    var blobInfo = blobInfo_;
+    if (blobInfo is not null)
+    {
+      return new ValueTask<BlobInfo>(blobInfo);
+    }
+
+    return Core();
+
+    async ValueTask<BlobInfo> Core()
+    {
+      // volatile read of blobInfoSource_ here has acquire semantics and with the combination
+      // of the volatile write of blobInfoSource_ below, it ensures that if we see a null value for blobInfoSource_,
+      // we are guaranteed to see a non-null value for blobInfo_.
+      var tcs = blobInfoSource_;
+      if (tcs is null)
+      {
+        return blobInfo_!;
+      }
+
+      var resolvedBlobInfo = await tcs.Task.ConfigureAwait(false);
+      blobInfo_ = resolvedBlobInfo;
+      // volatile write of blobInfoSource_ here has release semantics (allows other threads to see the effects of preceding operations).
+      // This prevent the compiler to do some operation reordering, then we are sure blobInfo_ has actually been assigned when we reach that point
+      // therefore if a thread can see a null blobInfoSource_, it is guaranteed to see a non-null blobInfo_.
+      blobInfoSource_ = null;
+      return resolvedBlobInfo;
+    }
+  }
+
+  /// <summary>
   ///   Asynchronously retrieves the state of the blob.
   /// </summary>
   /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
   /// <returns>A task representing the asynchronous operation. The task result contains the blob state.</returns>
   public async Task<BlobState> GetBlobStateAsync(CancellationToken cancellationToken = default)
-    => await ArmoniKClient.BlobService.GetBlobStateAsync(this,
-                                                         cancellationToken)
-                          .ConfigureAwait(false);
+  {
+    var blobInfo = await GetBlobInfoAsync()
+                     .ConfigureAwait(false);
+    return await ArmoniKClient.BlobService.GetBlobStateAsync(blobInfo,
+                                                             cancellationToken)
+                              .ConfigureAwait(false);
+  }
 
   /// <summary>
   ///   Asynchronously downloads the data of the blob.
@@ -115,9 +172,13 @@ public class BlobHandle
   /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
   /// <returns>A task representing the asynchronous operation. The task result contains the blob content as a byte array.</returns>
   public async Task<byte[]> DownloadBlobDataAsync(CancellationToken cancellationToken)
-    => await ArmoniKClient.BlobService.DownloadBlobAsync(this,
-                                                         cancellationToken)
-                          .ConfigureAwait(false);
+  {
+    var blobInfo = await GetBlobInfoAsync()
+                     .ConfigureAwait(false);
+    return await ArmoniKClient.BlobService.DownloadBlobAsync(blobInfo,
+                                                             cancellationToken)
+                              .ConfigureAwait(false);
+  }
 
   /// <summary>
   ///   Asynchronously downloads the data of the blob in chunks.
@@ -126,7 +187,9 @@ public class BlobHandle
   /// <returns>An asynchronous enumerable of byte arrays representing the blob data chunks.</returns>
   public async IAsyncEnumerable<byte[]> DownloadBlobDataWithChunksAsync([EnumeratorCancellation] CancellationToken cancellationToken)
   {
-    await foreach (var chunk in ArmoniKClient.BlobService.DownloadBlobWithChunksAsync(this,
+    var blobInfo = await GetBlobInfoAsync()
+                     .ConfigureAwait(false);
+    await foreach (var chunk in ArmoniKClient.BlobService.DownloadBlobWithChunksAsync(blobInfo,
                                                                                       cancellationToken)
                                              .ConfigureAwait(false))
     {
@@ -142,9 +205,13 @@ public class BlobHandle
   /// <returns>A task representing the asynchronous operation.</returns>
   public async Task UploadBlobDataAsync(ReadOnlyMemory<byte> blobContent,
                                         CancellationToken    cancellationToken)
+  {
+    var blobInfo = await GetBlobInfoAsync()
+                     .ConfigureAwait(false);
     // Upload the blob chunk
-    => await ArmoniKClient.BlobService.UploadBlobAsync(this,
-                                                       blobContent,
-                                                       cancellationToken)
-                          .ConfigureAwait(false);
+    await ArmoniKClient.BlobService.UploadBlobAsync(blobInfo,
+                                                    blobContent,
+                                                    cancellationToken)
+                       .ConfigureAwait(false);
+  }
 }

--- a/ArmoniK.Extensions.CSharp.Client/Handles/SessionHandle.cs
+++ b/ArmoniK.Extensions.CSharp.Client/Handles/SessionHandle.cs
@@ -265,6 +265,8 @@ public class SessionHandle : IAsyncDisposable, IDisposable
   {
     _ = task ?? throw new ArgumentNullException(nameof(task));
 
+    EnsureBlobHandles(task);
+
     var backgroundSubmitter = CreateBackgroundSubmitterIfNeeded(cancellationToken);
     var taskHandle          = TaskHandle.FromTaskCompletionSourceOfTaskInfos(ArmoniKClient);
     backgroundSubmitter.Add(task,
@@ -288,12 +290,28 @@ public class SessionHandle : IAsyncDisposable, IDisposable
     var taskHandles         = new TaskHandle[tasks.Count];
     for (var i = 0; i < tasks.Count; i++)
     {
+      var task = tasks.ElementAt(i);
+      EnsureBlobHandles(task);
       taskHandles[i] = TaskHandle.FromTaskCompletionSourceOfTaskInfos(ArmoniKClient);
-      backgroundSubmitter.Add(tasks.ElementAt(i),
+      backgroundSubmitter.Add(task,
                               taskHandles[i]);
     }
 
     return taskHandles;
+  }
+
+  /// <summary>
+  ///   Creates a pending <see cref="BlobHandle" /> for every input and output blob definition of the task that
+  ///   doesn't already have one, so that callers can await it right after this method returns, well before the
+  ///   background submitter has actually processed the task.
+  /// </summary>
+  /// <param name="task">The task definition whose blob definitions should get a pending handle.</param>
+  private void EnsureBlobHandles(TaskDefinition task)
+  {
+    foreach (var blobDefinition in task.InputDefinitions.Values.Union(task.Outputs.Values))
+    {
+      blobDefinition.EnsureBlobHandle(ArmoniKClient);
+    }
   }
 
   private class BackgroundSubmitter : IAsyncDisposable
@@ -412,7 +430,8 @@ public class SessionHandle : IAsyncDisposable, IDisposable
             {
               foreach (var blob in blobsWithCallbacks)
               {
-                callbackRunner.Add(blob);
+                await callbackRunner.AddAsync(blob)
+                                    .ConfigureAwait(false);
               }
             }
           }
@@ -531,9 +550,13 @@ public class SessionHandle : IAsyncDisposable, IDisposable
     ///   Register a new blob having a callback.
     /// </summary>
     /// <param name="blob">The blob definition carrying a callback</param>
-    public void Add(BlobDefinition blob)
-      => callbacks_.GetOrAdd(blob.BlobHandle!.BlobInfo.BlobId,
-                             blob.CallBack!);
+    public async Task AddAsync(BlobDefinition blob)
+    {
+      var blobInfo = await blob.BlobHandle!.GetBlobInfoAsync()
+                               .ConfigureAwait(false);
+      callbacks_.GetOrAdd(blobInfo.BlobId,
+                          blob.CallBack!);
+    }
 
     private async Task ExecuteCallback((ICallback callback, BlobState blobState) tuple)
     {

--- a/ArmoniK.Extensions.CSharp.Client/Services/BlobService.cs
+++ b/ArmoniK.Extensions.CSharp.Client/Services/BlobService.cs
@@ -29,7 +29,6 @@ using ArmoniK.Extensions.CSharp.Client.Common.Domain.Session;
 using ArmoniK.Extensions.CSharp.Client.Common.Enum;
 using ArmoniK.Extensions.CSharp.Client.Common.Services;
 using ArmoniK.Extensions.CSharp.Client.Exceptions;
-using ArmoniK.Extensions.CSharp.Client.Handles;
 using ArmoniK.Extensions.CSharp.Client.Queryable;
 using ArmoniK.Extensions.CSharp.Client.Queryable.BlobStateQuery;
 using ArmoniK.Extensions.CSharp.Common.Common.Domain.Blob;
@@ -455,12 +454,17 @@ public class BlobService : IBlobService
     using var stream = blobClient.UploadResultData(cancellationToken: cancellationToken);
     try
     {
+      // The blob's metadata (and hence its id) must already be known by this point: either the blob was
+      // already resolved on a previous call, or its metadata was just created by CreateBlobsMetadataAsync().
+      var blobInfo = blobDefinition.BlobHandle!.ResolvedBlobInfoOrNull ??
+                     throw new
+                       ArmoniKSdkException($"The blob '{blobDefinition.Name}' has no known id yet, its metadata must be created before uploading its data by chunk.");
       await stream.RequestStream.WriteAsync(new UploadResultDataRequest
                                             {
                                               Id = new UploadResultDataRequest.Types.ResultIdentifier
                                                    {
-                                                     ResultId  = blobDefinition.BlobHandle!.BlobInfo.BlobId,
-                                                     SessionId = blobDefinition.BlobHandle!.BlobInfo.SessionId,
+                                                     ResultId  = blobInfo.BlobId,
+                                                     SessionId = blobInfo.SessionId,
                                                    },
                                             })
                   .ConfigureAwait(false);
@@ -530,14 +534,48 @@ public class BlobService : IBlobService
                                      IEnumerable<BlobDefinition> blobDefinitions,
                                      CancellationToken           cancellationToken = default)
   {
+    var definitions = blobDefinitions as ICollection<BlobDefinition> ?? blobDefinitions.ToList();
+    foreach (var blobDefinition in definitions)
+    {
+      // Ensure every definition has a (possibly pending) handle, covering callers that bypass
+      // SessionHandle.Submit() (which already creates it eagerly).
+      blobDefinition.EnsureBlobHandle(armoniKClient_);
+    }
+
+    try
+    {
+      await CreateBlobsCoreAsync(session,
+                                 definitions,
+                                 cancellationToken)
+        .ConfigureAwait(false);
+    }
+    catch (Exception ex)
+    {
+      // Make sure no caller is left awaiting a handle that will never resolve: every handle in this
+      // call that isn't already resolved transitions to a faulted state (idempotent, safe no-op for
+      // already-resolved ones).
+      foreach (var blobDefinition in definitions)
+      {
+        blobDefinition.BlobHandle?.BlobInfoSource?.TrySetException(ex);
+      }
+
+      throw;
+    }
+  }
+
+  private async Task CreateBlobsCoreAsync(SessionInfo                 session,
+                                          IEnumerable<BlobDefinition> blobDefinitions,
+                                          CancellationToken           cancellationToken)
+  {
     var blobsWithData    = new List<BlobDefinition>();
     var blobsWithoutData = new List<BlobDefinition>();
 
     foreach (var blobDefinition in blobDefinitions)
     {
-      if (blobDefinition.BlobHandle != null)
+      var resolvedBlobInfo = blobDefinition.BlobHandle!.ResolvedBlobInfoOrNull;
+      if (resolvedBlobInfo != null)
       {
-        if (blobDefinition.BlobHandle.BlobInfo.SessionId == session.SessionId)
+        if (resolvedBlobInfo.SessionId == session.SessionId)
         {
           // The blob was already created on this session, then we skip it
           continue;
@@ -547,7 +585,7 @@ public class BlobService : IBlobService
         {
           // The blob was created on another session, and we do not have its data.
           throw new
-            ArmoniKSdkException($"The blob '{blobDefinition.BlobHandle.BlobInfo.BlobName}' (BlobId:{blobDefinition.BlobHandle.BlobInfo.BlobId}) was created on session '{blobDefinition.BlobHandle.BlobInfo.SessionId}' and cannot be used on session '{session.SessionId}'");
+            ArmoniKSdkException($"The blob '{resolvedBlobInfo.BlobName}' (BlobId:{resolvedBlobInfo.BlobId}) was created on session '{resolvedBlobInfo.SessionId}' and cannot be used on session '{session.SessionId}'");
         }
       }
 
@@ -627,8 +665,10 @@ public class BlobService : IBlobService
                                                 cancellationToken);
         await foreach (var blob in response.ConfigureAwait(false))
         {
-          name2Blob[blob.BlobName].BlobHandle = new BlobHandle(blob,
-                                                               armoniKClient_);
+          // TrySetResult (not SetResult): a blob whose size is above the chunking threshold is processed
+          // by both the metadata-creation section above and the content-upload section below, so this
+          // same handle may be resolved twice with an equivalent BlobInfo; the second call is then a no-op.
+          name2Blob[blob.BlobName].BlobHandle!.BlobInfoSource!.TrySetResult(blob);
         }
       }
     }
@@ -645,8 +685,10 @@ public class BlobService : IBlobService
                                                    cancellationToken);
         await foreach (var blob in response.ConfigureAwait(false))
         {
-          name2Blob[blob.BlobName].BlobHandle = new BlobHandle(blob,
-                                                               armoniKClient_);
+          // TrySetResult (not SetResult): a blob whose size is above the chunking threshold is processed
+          // by both the metadata-creation section above and the content-upload section below, so this
+          // same handle may be resolved twice with an equivalent BlobInfo; the second call is then a no-op.
+          name2Blob[blob.BlobName].BlobHandle!.BlobInfoSource!.TrySetResult(blob);
         }
       }
     }
@@ -711,7 +753,8 @@ public class BlobService : IBlobService
         await UploadBlobByChunkAsync(blobDefinition,
                                      cancellationToken: cancellationToken)
           .ConfigureAwait(false);
-        yield return blobDefinition.BlobHandle!;
+        // The metadata (and hence the BlobInfo) was already created earlier, by CreateBlobsMetadataAsync().
+        yield return blobDefinition.BlobHandle!.ResolvedBlobInfoOrNull!;
       }
       else
       {

--- a/ArmoniK.Extensions.CSharp.Client/Services/TasksService.cs
+++ b/ArmoniK.Extensions.CSharp.Client/Services/TasksService.cs
@@ -197,12 +197,23 @@ public class TasksService : ITasksService
     var tasksOutputs = new List<IEnumerable<KeyValuePair<string, string>>>();
     foreach (var task in taskDefinitions)
     {
-      var inputs = task.InputDefinitions.Select(i => new KeyValuePair<string, string>(i.Key,
-                                                                                      i.Value.BlobHandle!.BlobInfo.BlobId))
-                       .ToList();
-      var outputs = task.Outputs.Select(o => new KeyValuePair<string, string>(o.Key,
-                                                                              o.Value.BlobHandle!.BlobInfo.BlobId))
-                        .ToList();
+      var inputs = new List<KeyValuePair<string, string>>();
+      foreach (var i in task.InputDefinitions)
+      {
+        var blobInfo = await i.Value.BlobHandle!.GetBlobInfoAsync()
+                              .ConfigureAwait(false);
+        inputs.Add(new KeyValuePair<string, string>(i.Key,
+                                                    blobInfo.BlobId));
+      }
+
+      var outputs = new List<KeyValuePair<string, string>>();
+      foreach (var o in task.Outputs)
+      {
+        var blobInfo = await o.Value.BlobHandle!.GetBlobInfoAsync()
+                              .ConfigureAwait(false);
+        outputs.Add(new KeyValuePair<string, string>(o.Key,
+                                                     blobInfo.BlobId));
+      }
 
       var payload = new Payload(inputs.ToDictionary(b => b.Key,
                                                     b => b.Value),
@@ -236,7 +247,8 @@ public class TasksService : ITasksService
     {
       taskEnumerator.MoveNext();
       var task = taskEnumerator.Current;
-      task!.Payload                                                      = payloadBlobHandle!;
+      task!.Payload = await payloadBlobHandle!.GetBlobInfoAsync()
+                                              .ConfigureAwait(false);
       task.TaskOptions.Options[nameof(DynamicLibrary.ConventionVersion)] = DynamicLibrary.ConventionVersion;
       var dataDependencies = tasksInputs[index]
         .Select(i => i.Value);

--- a/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/CheckBlobCreationResponseOrderClient.cs
+++ b/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/CheckBlobCreationResponseOrderClient.cs
@@ -58,7 +58,9 @@ internal class CheckBlobCreationResponseOrderClient : ClientBase
 
     foreach (var blob in taskDefinition.Outputs.Values)
     {
-      var name = blob.BlobHandle!.BlobInfo.BlobName;
+      var blobInfo = await blob.BlobHandle!.GetBlobInfoAsync()
+                               .ConfigureAwait(false);
+      var name = blobInfo.BlobName;
       var data = ((Callback)blob.CallBack!).Result;
       Assert.That(data,
                   Is.EqualTo(name));
@@ -77,12 +79,13 @@ internal class CheckBlobCreationResponseOrderClient : ClientBase
       return ValueTask.CompletedTask;
     }
 
-    public ValueTask OnErrorAsync(BlobHandle        blob,
-                                  Exception?        exception,
-                                  CancellationToken cancellationToken)
+    public async ValueTask OnErrorAsync(BlobHandle        blob,
+                                        Exception?        exception,
+                                        CancellationToken cancellationToken)
     {
-      Assert.Fail(exception?.Message ?? $"blob {blob.BlobInfo.BlobId} aborted");
-      return ValueTask.CompletedTask;
+      var blobInfo = await blob.GetBlobInfoAsync()
+                               .ConfigureAwait(false);
+      Assert.Fail(exception?.Message ?? $"blob {blobInfo.BlobId} aborted");
     }
   }
 }

--- a/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/FailingTaskClient.cs
+++ b/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/FailingTaskClient.cs
@@ -62,12 +62,13 @@ internal class FailingTaskClient : ClientBase
 
     public bool Aborted { get; private set; }
 
-    public ValueTask OnSuccessAsync(BlobHandle        blob,
-                                    byte[]            rawData,
-                                    CancellationToken cancellationToken)
+    public async ValueTask OnSuccessAsync(BlobHandle        blob,
+                                          byte[]            rawData,
+                                          CancellationToken cancellationToken)
     {
-      Assert.Fail($"blob {blob.BlobInfo.BlobId} expected to be aborted");
-      return ValueTask.CompletedTask;
+      var blobInfo = await blob.GetBlobInfoAsync()
+                               .ConfigureAwait(false);
+      Assert.Fail($"blob {blobInfo.BlobId} expected to be aborted");
     }
 
     public async ValueTask OnErrorAsync(BlobHandle        blob,

--- a/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/GaussProblemClient.cs
+++ b/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/GaussProblemClient.cs
@@ -79,12 +79,13 @@ public class GaussProblemClient : ClientBase
       return ValueTask.CompletedTask;
     }
 
-    public ValueTask OnErrorAsync(BlobHandle        blob,
-                                  Exception?        exception,
-                                  CancellationToken cancellationToken)
+    public async ValueTask OnErrorAsync(BlobHandle        blob,
+                                        Exception?        exception,
+                                        CancellationToken cancellationToken)
     {
-      Assert.Fail(exception?.Message ?? $"blob {blob.BlobInfo.BlobId} aborted");
-      return ValueTask.CompletedTask;
+      var blobInfo = await blob.GetBlobInfoAsync()
+                               .ConfigureAwait(false);
+      Assert.Fail(exception?.Message ?? $"blob {blobInfo.BlobId} aborted");
     }
   }
 }

--- a/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/PriorityClient.cs
+++ b/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/PriorityClient.cs
@@ -19,6 +19,7 @@ using System.Text;
 using ArmoniK.Extensions.CSharp.Client.Common.Domain.Blob;
 using ArmoniK.Extensions.CSharp.Client.Common.Domain.Task;
 using ArmoniK.Extensions.CSharp.Client.Handles;
+using ArmoniK.Extensions.CSharp.Common.Common.Domain.Blob;
 
 namespace ArmoniK.EndToEndTests.Client.Tests;
 
@@ -77,8 +78,13 @@ public class PriorityClient : ClientBase
       taskDefinitions.Clear();
     }
 
-    var allResults = allTasks.SelectMany(t => t.Outputs.Values.Select(o => o.BlobHandle!.BlobInfo))
-                             .ToList();
+    var allResults = new List<BlobInfo>();
+    foreach (var blobHandle in allTasks.SelectMany(t => t.Outputs.Values.Select(o => o.BlobHandle!)))
+    {
+      allResults.Add(await blobHandle.GetBlobInfoAsync()
+                                     .ConfigureAwait(false));
+    }
+
     await Client!.EventsService.WaitForBlobsAsync(SessionHandle!,
                                                   allResults,
                                                   CancellationToken.None)

--- a/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/TaskSdkClient.cs
+++ b/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/TaskSdkClient.cs
@@ -67,11 +67,16 @@ public class TaskSdkClient : ClientBase
       resultString = Encoding.UTF8.GetString(callback.Result);
     }
 
+    var inputBlobInfo = await inputBlobHandle!.GetBlobInfoAsync()
+                                              .ConfigureAwait(false);
+    var outputBlobInfo = await outputBlobHandle!.GetBlobInfoAsync()
+                                                .ConfigureAwait(false);
+
     Assert.Multiple(() =>
                     {
-                      Assert.That(inputBlobHandle!.BlobInfo.BlobName,
+                      Assert.That(inputBlobInfo.BlobName,
                                   Is.EqualTo("blobInputString"));
-                      Assert.That(outputBlobHandle!.BlobInfo.BlobName,
+                      Assert.That(outputBlobInfo.BlobName,
                                   Is.EqualTo("blobOutputString"));
                       Assert.That(resultString,
                                   Is.EqualTo(str));
@@ -193,12 +198,13 @@ public class TaskSdkClient : ClientBase
       return ValueTask.CompletedTask;
     }
 
-    public ValueTask OnErrorAsync(BlobHandle        blob,
-                                  Exception?        exception,
-                                  CancellationToken cancellationToken)
+    public async ValueTask OnErrorAsync(BlobHandle        blob,
+                                        Exception?        exception,
+                                        CancellationToken cancellationToken)
     {
-      Assert.Fail(exception?.Message ?? $"blob {blob.BlobInfo.BlobId} aborted");
-      return ValueTask.CompletedTask;
+      var blobInfo = await blob.GetBlobInfoAsync()
+                               .ConfigureAwait(false);
+      Assert.Fail(exception?.Message ?? $"blob {blobInfo.BlobId} aborted");
     }
   }
 }

--- a/Tests/Handles/BlobHandleTests.cs
+++ b/Tests/Handles/BlobHandleTests.cs
@@ -43,14 +43,16 @@ public class BlobHandleTests
   private BlobInfo?            mockBlobInfo_;
 
   [Test]
-  public void ConstructorWithBlobInfosShouldInitializeProperties()
+  public async Task ConstructorWithBlobInfosShouldInitializeProperties()
   {
     var blobHandle = new BlobHandle(mockBlobInfo_!,
                                     mockedArmoniKClient_!);
 
+    var blobInfo = await blobHandle.GetBlobInfoAsync();
+
     Assert.Multiple(() =>
                     {
-                      Assert.That(blobHandle.BlobInfo,
+                      Assert.That(blobInfo,
                                   Is.EqualTo(mockBlobInfo_));
                       Assert.That(blobHandle.ArmoniKClient,
                                   Is.Not.Null);
@@ -60,7 +62,7 @@ public class BlobHandleTests
   }
 
   [Test]
-  public void ConstructorWithIndividualParametersShouldInitializeCorrectly()
+  public async Task ConstructorWithIndividualParametersShouldInitializeCorrectly()
   {
     var blobName  = "myBlob";
     var blobId    = "myId";
@@ -71,13 +73,15 @@ public class BlobHandleTests
                                     sessionId,
                                     mockedArmoniKClient_!);
 
+    var blobInfo = await blobHandle.GetBlobInfoAsync();
+
     Assert.Multiple(() =>
                     {
-                      Assert.That(blobHandle.BlobInfo.BlobName,
+                      Assert.That(blobInfo.BlobName,
                                   Is.EqualTo(blobName));
-                      Assert.That(blobHandle.BlobInfo.BlobId,
+                      Assert.That(blobInfo.BlobId,
                                   Is.EqualTo(blobId));
-                      Assert.That(blobHandle.BlobInfo.SessionId,
+                      Assert.That(blobInfo.SessionId,
                                   Is.EqualTo(sessionId));
                       Assert.That(blobHandle.ArmoniKClient,
                                   Is.Not.Null);
@@ -99,39 +103,71 @@ public class BlobHandleTests
                          .EqualTo("armoniKClient"));
 
   [Test]
-  public void ImplicitConversionToBlobInfoShouldReturnCorrectBlobInfo()
+  public void ResolvedHandleGetBlobInfoAsyncCompletesSynchronously()
   {
     var blobHandle = new BlobHandle(mockBlobInfo_!,
                                     mockedArmoniKClient_!);
 
-    BlobInfo convertedBlobInfo = blobHandle;
+    var valueTask = blobHandle.GetBlobInfoAsync();
 
-    Assert.That(convertedBlobInfo,
+    Assert.Multiple(() =>
+                    {
+                      Assert.That(valueTask.IsCompletedSuccessfully,
+                                  Is.True);
+                      Assert.That(valueTask.Result,
+                                  Is.EqualTo(mockBlobInfo_));
+                    });
+  }
+
+  [Test]
+  public void PendingHandleGetBlobInfoAsyncDoesNotCompleteBeforeResolution()
+  {
+    var blobHandle = new BlobHandle(mockedArmoniKClient_!);
+
+    var task = blobHandle.GetBlobInfoAsync()
+                         .AsTask();
+
+    Assert.That(task.IsCompleted,
+                Is.False);
+  }
+
+  [Test]
+  public async Task PendingHandleGetBlobInfoAsyncCompletesOnceResolved()
+  {
+    var blobHandle = new BlobHandle(mockedArmoniKClient_!);
+
+    var task = blobHandle.GetBlobInfoAsync()
+                         .AsTask();
+
+    blobHandle.BlobInfoSource!.SetResult(mockBlobInfo_!);
+
+    var blobInfo = await task;
+
+    Assert.That(blobInfo,
                 Is.EqualTo(mockBlobInfo_));
   }
 
   [Test]
-  public void ImplicitConversionToBlobInfoThrowsArgumentNullExceptionWhenHandleIsNull()
+  public void PendingHandleGetBlobInfoAsyncFaultsWhenFailed()
   {
-    BlobHandle? nullHandle = null;
+    var blobHandle = new BlobHandle(mockedArmoniKClient_!);
 
-    Assert.That(() =>
-                {
-                  BlobInfo _ = nullHandle!;
-                },
-                Throws.ArgumentNullException.With.Property(nameof(ArgumentNullException.ParamName))
-                      .EqualTo("blobHandle"));
+    var task = blobHandle.GetBlobInfoAsync()
+                         .AsTask();
+
+    var expectedException = new InvalidOperationException("blob creation failed");
+    blobHandle.BlobInfoSource!.SetException(expectedException);
+
+    Assert.That(async () => await task,
+                Throws.InvalidOperationException.With.Message.EqualTo(expectedException.Message));
   }
 
   [Test]
-  public void ImplicitConversionWorksInMethodParameters()
+  public void PendingHandleResolvedBlobInfoOrNullIsNullBeforeResolution()
   {
-    var blobHandle = new BlobHandle(mockBlobInfo_!,
-                                    mockedArmoniKClient_!);
+    var blobHandle = new BlobHandle(mockedArmoniKClient_!);
 
-    // we make sure that we can use BlobHandle where BlobInfo is expected
-    Assert.That(() => Assert.That(blobHandle,
-                                  Is.Not.Null),
-                Throws.Nothing);
+    Assert.That(blobHandle.ResolvedBlobInfoOrNull,
+                Is.Null);
   }
 }

--- a/Tests/Services/TasksServiceTests.cs
+++ b/Tests/Services/TasksServiceTests.cs
@@ -321,6 +321,9 @@ public class TasksServiceTests
                              .ConfigureAwait(false);
 
     var dependencyData = mock.GetBlobDataSent(dependency.blobName);
+    var dependencyBlobInfo = await taskDefinition.InputDefinitions.First()
+                                                 .Value.BlobHandle!.GetBlobInfoAsync()
+                                                 .ConfigureAwait(false);
 
     mock.CheckConfigureBlobCreationResponseCount();
     Assert.Multiple(() =>
@@ -332,8 +335,7 @@ public class TasksServiceTests
                                                    .DataDependencies.First()),
                                   "Expected data dependency blob ID to match.");
                       Assert.That(dependency.blobId,
-                                  Is.EqualTo(taskDefinition.InputDefinitions.First()
-                                                           .Value.BlobHandle!.BlobInfo.BlobId),
+                                  Is.EqualTo(dependencyBlobInfo.BlobId),
                                   "Expected data dependency blob ID in task definition to match.");
                     });
   }

--- a/UsageExample/Program.cs
+++ b/UsageExample/Program.cs
@@ -22,7 +22,6 @@ using ArmoniK.Extensions.CSharp.Client.Common;
 using ArmoniK.Extensions.CSharp.Client.Common.Domain.Blob;
 using ArmoniK.Extensions.CSharp.Client.Common.Domain.Task;
 using ArmoniK.Extensions.CSharp.Client.Services;
-using ArmoniK.Extensions.CSharp.Common.Common.Domain.Blob;
 using ArmoniK.Extensions.CSharp.Common.Common.Domain.Task;
 using ArmoniK.Extensions.CSharp.Common.Library;
 
@@ -111,8 +110,9 @@ internal class Program
     var taskInfo = await taskHandle.GetTaskInfosAsync()
                                    .ConfigureAwait(false);
 
-    BlobInfo resultBlobInfo = task.Outputs.Values.First()
-                                  .BlobHandle!;
+    var resultBlobInfo = await task.Outputs.Values.First()
+                                   .BlobHandle!.GetBlobInfoAsync()
+                                   .ConfigureAwait(false);
     logger.LogInformation("resultId: {ResultId}",
                           resultBlobInfo.BlobId);
     logger.LogInformation("taskId: {TaskId}",


### PR DESCRIPTION
# Motivation

`BlobDefinition.BlobHandle` was a plain nullable property, only set once `BlobService.CreateBlobsAsync` created the blob. Since `SessionHandle.Submit()` can return before the background submitter loop actually creates the blob, a caller reading `.BlobHandle` right after `Submit()` had no guarantee it was populated.

This was attempted before in PR #84 (reverted  by #85): it made the property async only for external callers while internal code kept reading the raw field, a two-tier fix that solved nothing structurally. This PR makes `BlobHandle` itself async-native instead, mirroring the existing `TaskHandle` pattern, with one code path for internal and external callers alike.

# Description

- `BlobHandle` gains a pending state backed by a `TaskCompletionSource<BlobInfo>`, exposed via
  `GetBlobInfoAsync()`, replacing the removed implicit `BlobHandle` → `BlobInfo` conversion.
- The pending handle is created in `SessionHandle.Submit()`, before the task reaches the
  background submitter, closing the actual race window.
- `BlobService.CreateBlobsAsync` resolves it (`TrySetResult`, safe to call twice for chunked
  blobs) or fails it (`TrySetException`) on error, so no caller ever awaits a handle that never
  resolves.
- Call sites across `TasksService`, `End2EndTests`, `UsageExample`, and `Tests` were updated from
  `.BlobHandle!.BlobInfo.X` to `(await ....GetBlobInfoAsync()).X`.

# Testing

Existing unit tests adapted  and passing. 

# Impact

- **Breaking:** the implicit `BlobHandle` → `BlobInfo` conversion is removed; use
  `await handle.GetBlobInfoAsync()`.

# Additional Information

N/A

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.