### PR TITLE
feat: split client-side BlobDefinition into (Input/Output)BlobDefinition

### DIFF
--- a/ArmoniK.Extensions.CSharp.Client/Common/Domain/Blob/BlobDefinition.cs
+++ b/ArmoniK.Extensions.CSharp.Client/Common/Domain/Blob/BlobDefinition.cs
@@ -18,31 +18,30 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading;
 
-using ArmoniK.Extensions.CSharp.Client.Exceptions;
 using ArmoniK.Extensions.CSharp.Client.Handles;
 
 namespace ArmoniK.Extensions.CSharp.Client.Common.Domain.Blob;
 
 /// <summary>
-///   Description of a blob that serve to its creation
+///   Description of a blob that serve to its creation. Only <see cref="InputBlobDefinition" /> and
+///   <see cref="OutputBlobDefinition" /> may derive from this class.
 /// </summary>
-public class BlobDefinition
+public abstract class BlobDefinition
 {
-  private readonly FileInfo?             file_;
-  private          BlobHandle?           blobHandle_;
-  private          long                  dataSize_;
-  private          ReadOnlyMemory<byte>? data_;
+  private readonly  FileInfo?             file_;
+  private protected BlobHandle?           blobHandle_;
+  private           long                  dataSize_;
+  private           ReadOnlyMemory<byte>? data_;
 
   /// <summary>
   ///   Creation of a blob definition with known data
   /// </summary>
   /// <param name="name">The blob name</param>
   /// <param name="content">The blob data</param>
-  private BlobDefinition(string               name,
-                         ReadOnlyMemory<byte> content)
+  private protected BlobDefinition(string               name,
+                                   ReadOnlyMemory<byte> content)
   {
     Name      = name;
     data_     = content;
@@ -56,8 +55,8 @@ public class BlobDefinition
   /// </summary>
   /// <param name="name">The blob name</param>
   /// <param name="file">The FileInfo instance</param>
-  private BlobDefinition(string   name,
-                         FileInfo file)
+  private protected BlobDefinition(string   name,
+                                   FileInfo file)
   {
     Name      = name;
     data_     = null;
@@ -70,7 +69,7 @@ public class BlobDefinition
   ///   Creation of a blob definition with no data
   /// </summary>
   /// <param name="name">The blob name</param>
-  private BlobDefinition(string name)
+  private protected BlobDefinition(string name)
   {
     Name      = name;
     data_     = null;
@@ -284,14 +283,6 @@ public class BlobDefinition
   }
 
   /// <summary>
-  ///   Create an output blob definition
-  /// </summary>
-  /// <param name="name">The blob name</param>
-  /// <returns>The newly created blob definition</returns>
-  public static BlobDefinition CreateOutput(string name)
-    => new(name);
-
-  /// <summary>
   ///   Set the blob as to be manually deleted
   /// </summary>
   /// <returns>The updated BlobDefinition</returns>
@@ -311,76 +302,4 @@ public class BlobDefinition
     CallBack = callBack;
     return this;
   }
-
-  /// <summary>
-  ///   Creates a BlobDefinition from a blob handle. The handle must already be resolved (i.e. reference an
-  ///   existing blob), since the blob's name is required immediately.
-  /// </summary>
-  /// <param name="handle">The blob handle</param>
-  /// <returns>The newly created blob definition</returns>
-  /// <exception cref="ArmoniKSdkException">Thrown when the handle is not resolved yet.</exception>
-  public static BlobDefinition FromBlobHandle(BlobHandle handle)
-  {
-    var blobInfo = handle.ResolvedBlobInfoOrNull ?? throw new ArmoniKSdkException("The blob handle must be resolved before it can be used to create a BlobDefinition.");
-    var definition = new BlobDefinition(blobInfo.BlobName)
-                     {
-                       blobHandle_ = handle,
-                     };
-    return definition;
-  }
-
-  /// <summary>
-  ///   Creates a BlobDefinition from a file
-  /// </summary>
-  /// <param name="blobName">The blob name</param>
-  /// <param name="filePath">The file containing the data</param>
-  /// <returns>The newly created blob definition</returns>
-  public static BlobDefinition FromFile(string blobName,
-                                        string filePath)
-  {
-    var file = new FileInfo(filePath);
-    if (!file.Exists)
-    {
-      throw new ArmoniKSdkException($"The file {file.FullName} does not exists.");
-    }
-
-    return new BlobDefinition(blobName,
-                              file);
-  }
-
-  /// <summary>
-  ///   Creates a BlobDefinition from a string
-  /// </summary>
-  /// <param name="blobName">The blob name</param>
-  /// <param name="content">The raw data</param>
-  /// <param name="encoding">The encoding used for the string, when null UTF-8 is used</param>
-  /// <returns>The newly created blob definition</returns>
-  public static BlobDefinition FromString(string    blobName,
-                                          string    content,
-                                          Encoding? encoding = null)
-    => new(blobName,
-           (encoding ?? Encoding.UTF8).GetBytes(content)
-                                      .AsMemory());
-
-  /// <summary>
-  ///   Creates a BlobDefinition from a read only memory
-  /// </summary>
-  /// <param name="blobName">The blob name</param>
-  /// <param name="content">The raw data</param>
-  /// <returns>The newly created blob definition</returns>
-  public static BlobDefinition FromReadOnlyMemory(string               blobName,
-                                                  ReadOnlyMemory<byte> content)
-    => new(blobName,
-           content);
-
-  /// <summary>
-  ///   Creates a BlobDefinition from a byte array
-  /// </summary>
-  /// <param name="blobName">The blob name</param>
-  /// <param name="content">The raw data</param>
-  /// <returns>The newly created blob definition</returns>
-  public static BlobDefinition FromByteArray(string blobName,
-                                             byte[] content)
-    => new(blobName,
-           content);
 }

--- a/ArmoniK.Extensions.CSharp.Client/Common/Domain/Blob/InputBlobDefinition.cs
+++ b/ArmoniK.Extensions.CSharp.Client/Common/Domain/Blob/InputBlobDefinition.cs
@@ -1,0 +1,134 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2026. All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.IO;
+using System.Text;
+
+using ArmoniK.Extensions.CSharp.Client.Exceptions;
+using ArmoniK.Extensions.CSharp.Client.Handles;
+
+namespace ArmoniK.Extensions.CSharp.Client.Common.Domain.Blob;
+
+/// <summary>
+///   Description of a blob to be used as a task input.
+/// </summary>
+public sealed class InputBlobDefinition : BlobDefinition
+{
+  private InputBlobDefinition(string               name,
+                              ReadOnlyMemory<byte> content)
+    : base(name,
+           content)
+  {
+  }
+
+  private InputBlobDefinition(string   name,
+                              FileInfo file)
+    : base(name,
+           file)
+  {
+  }
+
+  private InputBlobDefinition(string name)
+    : base(name)
+  {
+  }
+
+  /// <summary>
+  ///   Creates an InputBlobDefinition from a blob handle. The handle must already be resolved (i.e. reference an
+  ///   existing blob), since the blob's name is required immediately.
+  /// </summary>
+  /// <param name="handle">The blob handle</param>
+  /// <returns>The newly created blob definition</returns>
+  /// <exception cref="ArmoniKSdkException">Thrown when the handle is not resolved yet.</exception>
+  public static InputBlobDefinition FromBlobHandle(BlobHandle handle)
+  {
+    var blobInfo = handle.ResolvedBlobInfoOrNull ?? throw new ArmoniKSdkException("The blob handle must be resolved before it can be used to create a BlobDefinition.");
+    return new InputBlobDefinition(blobInfo.BlobName)
+           {
+             blobHandle_ = handle,
+           };
+  }
+
+  /// <summary>
+  ///   Creates an InputBlobDefinition from a file
+  /// </summary>
+  /// <param name="blobName">The blob name</param>
+  /// <param name="filePath">The file containing the data</param>
+  /// <returns>The newly created blob definition</returns>
+  public static InputBlobDefinition FromFile(string blobName,
+                                             string filePath)
+  {
+    var file = new FileInfo(filePath);
+    if (!file.Exists)
+    {
+      throw new ArmoniKSdkException($"The file {file.FullName} does not exists.");
+    }
+
+    return new InputBlobDefinition(blobName,
+                                   file);
+  }
+
+  /// <summary>
+  ///   Creates an InputBlobDefinition from a string
+  /// </summary>
+  /// <param name="blobName">The blob name</param>
+  /// <param name="content">The raw data</param>
+  /// <param name="encoding">The encoding used for the string, when null UTF-8 is used</param>
+  /// <returns>The newly created blob definition</returns>
+  public static InputBlobDefinition FromString(string    blobName,
+                                               string    content,
+                                               Encoding? encoding = null)
+    => new(blobName,
+           (encoding ?? Encoding.UTF8).GetBytes(content)
+                                      .AsMemory());
+
+  /// <summary>
+  ///   Creates an InputBlobDefinition from a read only memory
+  /// </summary>
+  /// <param name="blobName">The blob name</param>
+  /// <param name="content">The raw data</param>
+  /// <returns>The newly created blob definition</returns>
+  public static InputBlobDefinition FromReadOnlyMemory(string               blobName,
+                                                       ReadOnlyMemory<byte> content)
+    => new(blobName,
+           content);
+
+  /// <summary>
+  ///   Creates an InputBlobDefinition from a byte array
+  /// </summary>
+  /// <param name="blobName">The blob name</param>
+  /// <param name="content">The raw data</param>
+  /// <returns>The newly created blob definition</returns>
+  public static InputBlobDefinition FromByteArray(string blobName,
+                                                  byte[] content)
+    => new(blobName,
+           content);
+
+  /// <inheritdoc cref="BlobDefinition.WithManualDeletion" />
+  public new InputBlobDefinition WithManualDeletion()
+  {
+    base.WithManualDeletion();
+    return this;
+  }
+
+  /// <inheritdoc cref="BlobDefinition.WithCallback" />
+  public new InputBlobDefinition WithCallback(ICallback callBack)
+  {
+    base.WithCallback(callBack);
+    return this;
+  }
+}

--- a/ArmoniK.Extensions.CSharp.Client/Common/Domain/Blob/OutputBlobDefinition.cs
+++ b/ArmoniK.Extensions.CSharp.Client/Common/Domain/Blob/OutputBlobDefinition.cs
@@ -1,0 +1,51 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2026. All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace ArmoniK.Extensions.CSharp.Client.Common.Domain.Blob;
+
+/// <summary>
+///   Description of a blob to be produced as a task output. Unlike <see cref="InputBlobDefinition" />, it can never
+///   wrap an already-existing blob: a task output is always a fresh blob.
+/// </summary>
+public sealed class OutputBlobDefinition : BlobDefinition
+{
+  private OutputBlobDefinition(string name)
+    : base(name)
+  {
+  }
+
+  /// <summary>
+  ///   Create an output blob definition
+  /// </summary>
+  /// <param name="name">The blob name</param>
+  /// <returns>The newly created blob definition</returns>
+  public static OutputBlobDefinition CreateOutput(string name)
+    => new(name);
+
+  /// <inheritdoc cref="BlobDefinition.WithManualDeletion" />
+  public new OutputBlobDefinition WithManualDeletion()
+  {
+    base.WithManualDeletion();
+    return this;
+  }
+
+  /// <inheritdoc cref="BlobDefinition.WithCallback" />
+  public new OutputBlobDefinition WithCallback(ICallback callBack)
+  {
+    base.WithCallback(callBack);
+    return this;
+  }
+}

--- a/ArmoniK.Extensions.CSharp.Client/Common/Domain/Task/TaskDefinition.cs
+++ b/ArmoniK.Extensions.CSharp.Client/Common/Domain/Task/TaskDefinition.cs
@@ -17,7 +17,6 @@
 using System.Collections.Generic;
 
 using ArmoniK.Extensions.CSharp.Client.Common.Domain.Blob;
-using ArmoniK.Extensions.CSharp.Client.Exceptions;
 using ArmoniK.Extensions.CSharp.Common.Common.Domain.Blob;
 using ArmoniK.Extensions.CSharp.Common.Common.Domain.Task;
 using ArmoniK.Extensions.CSharp.Common.Library;
@@ -32,12 +31,12 @@ public class TaskDefinition
   /// <summary>
   ///   Input Blobs to be created
   /// </summary>
-  public Dictionary<string, BlobDefinition> InputDefinitions { get; } = new();
+  public Dictionary<string, InputBlobDefinition> InputDefinitions { get; } = new();
 
   /// <summary>
   ///   Output blobs
   /// </summary>
-  public Dictionary<string, BlobDefinition> Outputs { get; } = new();
+  public Dictionary<string, OutputBlobDefinition> Outputs { get; } = new();
 
   /// <summary>
   ///   Task options
@@ -72,8 +71,8 @@ public class TaskDefinition
   /// <param name="inputName">The blob's input name (which may differ from blob's name)</param>
   /// <param name="blobDeclaration">The blob definition</param>
   /// <returns>The TaskDefinition updated</returns>
-  public TaskDefinition WithInput(string         inputName,
-                                  BlobDefinition blobDeclaration)
+  public TaskDefinition WithInput(string              inputName,
+                                  InputBlobDefinition blobDeclaration)
   {
     InputDefinitions.Add(inputName,
                          blobDeclaration);
@@ -86,16 +85,9 @@ public class TaskDefinition
   /// <param name="outputName">The blob's output name (which may differ from blob's name)</param>
   /// <param name="blobDeclaration">The output blob's definition</param>
   /// <returns>The TaskDefinition updated</returns>
-  public TaskDefinition WithOutput(string         outputName,
-                                   BlobDefinition blobDeclaration)
+  public TaskDefinition WithOutput(string               outputName,
+                                   OutputBlobDefinition blobDeclaration)
   {
-    if (blobDeclaration.BlobHandle != null)
-    {
-      var resolvedBlobInfo = blobDeclaration.BlobHandle.ResolvedBlobInfoOrNull;
-      throw new
-        ArmoniKSdkException($"The task cannot take as output the already created blob '{resolvedBlobInfo?.BlobName}' with with BlobId '{resolvedBlobInfo?.BlobId}'");
-    }
-
     Outputs.Add(outputName,
                 blobDeclaration);
     return this;

--- a/ArmoniK.Extensions.CSharp.Client/Handles/SessionHandle.cs
+++ b/ArmoniK.Extensions.CSharp.Client/Handles/SessionHandle.cs
@@ -308,7 +308,7 @@ public class SessionHandle : IAsyncDisposable, IDisposable
   /// <param name="task">The task definition whose blob definitions should get a pending handle.</param>
   private void EnsureBlobHandles(TaskDefinition task)
   {
-    foreach (var blobDefinition in task.InputDefinitions.Values.Union(task.Outputs.Values))
+    foreach (var blobDefinition in task.InputDefinitions.Values.Union<BlobDefinition>(task.Outputs.Values))
     {
       blobDefinition.EnsureBlobHandle(ArmoniKClient);
     }

--- a/ArmoniK.Extensions.CSharp.Client/Services/TasksService.cs
+++ b/ArmoniK.Extensions.CSharp.Client/Services/TasksService.cs
@@ -186,7 +186,7 @@ public class TasksService : ITasksService
 
     // Create all blobs from blob definitions
     await blobService_.CreateBlobsAsync(session,
-                                        taskDefinitions.SelectMany(t => t.InputDefinitions.Values.Union(t.Outputs.Values))
+                                        taskDefinitions.SelectMany(t => t.InputDefinitions.Values.Union<BlobDefinition>(t.Outputs.Values))
                                                        .Distinct(),
                                         cancellationToken)
                       .ConfigureAwait(false);
@@ -235,8 +235,8 @@ public class TasksService : ITasksService
     var payloadsDefinition = payloadsJson.Select(p =>
                                                  {
                                                    payloadIndex++;
-                                                   return BlobDefinition.FromString("payload" + payloadIndex,
-                                                                                    p);
+                                                   return InputBlobDefinition.FromString("payload" + payloadIndex,
+                                                                                         p);
                                                  })
                                          .ToList();
     await blobService_.CreateBlobsAsync(session,

--- a/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/CheckBlobCreationResponseOrderClient.cs
+++ b/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/CheckBlobCreationResponseOrderClient.cs
@@ -44,11 +44,11 @@ internal class CheckBlobCreationResponseOrderClient : ClientBase
     foreach (var city in cities)
     {
       taskDefinition.WithInput(city,
-                               BlobDefinition.FromString(city,
-                                                         city))
+                               InputBlobDefinition.FromString(city,
+                                                              city))
                     .WithOutput(city,
-                                BlobDefinition.CreateOutput(city)
-                                              .WithCallback(new Callback()));
+                                OutputBlobDefinition.CreateOutput(city)
+                                                    .WithCallback(new Callback()));
     }
 
     SessionHandle!.Submit(taskDefinition);

--- a/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/FailingTaskClient.cs
+++ b/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/FailingTaskClient.cs
@@ -38,11 +38,11 @@ internal class FailingTaskClient : ClientBase
     var callback = new Callback(SessionHandle!);
     var taskDefinition = new TaskDefinition().WithLibrary(WorkerLibrary!)
                                              .WithInput("inputString",
-                                                        BlobDefinition.FromString("blobInputString",
-                                                                                  "Hello world!"))
+                                                        InputBlobDefinition.FromString("blobInputString",
+                                                                                       "Hello world!"))
                                              .WithOutput("outputString",
-                                                         BlobDefinition.CreateOutput("blobOutputString")
-                                                                       .WithCallback(callback))
+                                                         OutputBlobDefinition.CreateOutput("blobOutputString")
+                                                                             .WithCallback(callback))
                                              .WithTaskOptions(TaskConfiguration!);
     SessionHandle!.Submit([taskDefinition]);
 

--- a/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/GaussProblemClient.cs
+++ b/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/GaussProblemClient.cs
@@ -46,13 +46,13 @@ public class GaussProblemClient : ClientBase
     var task = new TaskDefinition().WithLibrary(WorkerLibrary!)
                                    .WithTaskOptions(TaskConfiguration!)
                                    .WithOutput("result",
-                                               BlobDefinition.CreateOutput("resultBlob")
-                                                             .WithCallback(callback));
+                                               OutputBlobDefinition.CreateOutput("resultBlob")
+                                                                   .WithCallback(callback));
     for (var i = 1; i <= N; i++)
     {
       task.WithInput("blob" + i,
-                     BlobDefinition.FromString("input" + 1,
-                                               i.ToString()));
+                     InputBlobDefinition.FromString("input" + 1,
+                                                    i.ToString()));
     }
 
     SessionHandle!.Submit(task);

--- a/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/PriorityClient.cs
+++ b/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/PriorityClient.cs
@@ -63,9 +63,9 @@ public class PriorityClient : ClientBase
         var resultName = "Result" + priority;
         var taskDefinition = new TaskDefinition().WithLibrary(WorkerLibrary!)
                                                  .WithInput("Priority",
-                                                            BlobDefinition.FromBlobHandle(priorityBlobHandle))
+                                                            InputBlobDefinition.FromBlobHandle(priorityBlobHandle))
                                                  .WithOutput(resultName,
-                                                             BlobDefinition.CreateOutput(resultName))
+                                                             OutputBlobDefinition.CreateOutput(resultName))
                                                  .WithTaskOptions(options);
         taskDefinitions.Add(taskDefinition);
       }

--- a/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/TaskSdkClient.cs
+++ b/End2EndTests/ArmoniK.EndToEndTests.Client/Tests/TaskSdkClient.cs
@@ -44,11 +44,11 @@ public class TaskSdkClient : ClientBase
     var callback = new Callback();
     var taskDefinition = new TaskDefinition().WithLibrary(WorkerLibrary!)
                                              .WithInput("inputString",
-                                                        BlobDefinition.FromString("blobInputString",
-                                                                                  str))
+                                                        InputBlobDefinition.FromString("blobInputString",
+                                                                                       str))
                                              .WithOutput("outputString",
-                                                         BlobDefinition.CreateOutput("blobOutputString")
-                                                                       .WithCallback(callback))
+                                                         OutputBlobDefinition.CreateOutput("blobOutputString")
+                                                                             .WithCallback(callback))
                                              .WithTaskOptions(TaskConfiguration!);
     SessionHandle!.Submit([taskDefinition]);
 
@@ -89,11 +89,11 @@ public class TaskSdkClient : ClientBase
     var callback = new Callback();
     var taskDefinition = new TaskDefinition().WithLibrary(WorkerLibrary!)
                                              .WithInput("inputString",
-                                                        BlobDefinition.FromString("blobInputString",
-                                                                                  "Hello!"))
+                                                        InputBlobDefinition.FromString("blobInputString",
+                                                                                       "Hello!"))
                                              .WithOutput("outputString",
-                                                         BlobDefinition.CreateOutput("blobOutputString")
-                                                                       .WithCallback(callback))
+                                                         OutputBlobDefinition.CreateOutput("blobOutputString")
+                                                                             .WithCallback(callback))
                                              .WithTaskOptions(TaskConfiguration!);
     var taskInfo = await Client!.TasksService.SubmitTasksAsync(SessionHandle!,
                                                                [taskDefinition])
@@ -164,11 +164,11 @@ public class TaskSdkClient : ClientBase
     {
       taskDefinitions.Add(new TaskDefinition().WithLibrary(WorkerLibrary!)
                                               .WithInput("inputString",
-                                                         BlobDefinition.FromString("blobInputString" + i,
-                                                                                   str))
+                                                         InputBlobDefinition.FromString("blobInputString" + i,
+                                                                                        str))
                                               .WithOutput("outputString",
-                                                          BlobDefinition.CreateOutput("blobOutputString" + i)
-                                                                        .WithCallback(new Callback()))
+                                                          OutputBlobDefinition.CreateOutput("blobOutputString" + i)
+                                                                              .WithCallback(new Callback()))
                                               .WithTaskOptions(TaskConfiguration!));
     }
 

--- a/Tests/Common/Domain/BlobDefinitionTests.cs
+++ b/Tests/Common/Domain/BlobDefinitionTests.cs
@@ -43,8 +43,8 @@ public class BlobDefinitionTests
   [Test]
   public async Task TestBlobFile1()
   {
-    var blob = BlobDefinition.FromFile("file1",
-                                       testFileName_);
+    var blob = InputBlobDefinition.FromFile("file1",
+                                            testFileName_);
     blob.RefreshFile();
     var result = await blob.GetDataAsync()
                            .SingleAsync()
@@ -57,8 +57,8 @@ public class BlobDefinitionTests
   [Test]
   public async Task TestBlobFile2()
   {
-    var blob = BlobDefinition.FromFile("file1",
-                                       testFileName_);
+    var blob = InputBlobDefinition.FromFile("file1",
+                                            testFileName_);
     blob.RefreshFile();
     var globalBytes = new List<byte>();
     await foreach (var result in blob.GetDataAsync(30)
@@ -74,8 +74,8 @@ public class BlobDefinitionTests
   [Test]
   public async Task TestBlobFile3()
   {
-    var blob = BlobDefinition.FromFile("file1",
-                                       testFileName_);
+    var blob = InputBlobDefinition.FromFile("file1",
+                                            testFileName_);
     blob.RefreshFile();
     var result = await blob.GetDataAsync(200)
                            .SingleAsync()

--- a/Tests/Services/TasksServiceTests.cs
+++ b/Tests/Services/TasksServiceTests.cs
@@ -77,8 +77,8 @@ public class TasksServiceTests
                                                                payload2)
                         .Stop();
 
-    var blobDefinition = BlobDefinition.FromString(blob.blobName,
-                                                   "Hello!");
+    var blobDefinition = InputBlobDefinition.FromString(blob.blobName,
+                                                        "Hello!");
 
     // Configure task submission response
     (string taskId, string payloadId, string[]? inputs, string[]? outputs) task1 =
@@ -86,14 +86,14 @@ public class TasksServiceTests
     var taskDefinition1 = new TaskDefinition().WithInput("param1",
                                                          blobDefinition)
                                               .WithOutput("result1",
-                                                          BlobDefinition.CreateOutput(outputBlob1.blobName))
+                                                          OutputBlobDefinition.CreateOutput(outputBlob1.blobName))
                                               .WithTaskOptions(taskOption);
     (string taskId, string payloadId, string[]? inputs, string[]? outputs) task2 =
       (taskId: "taskId2", payloadId: payload2.blobId, inputs: [blob.blobId], outputs: [outputBlob2.blobId]);
     var taskDefinition2 = new TaskDefinition().WithInput("param2",
                                                          blobDefinition)
                                               .WithOutput("result2",
-                                                          BlobDefinition.CreateOutput(outputBlob2.blobName))
+                                                          OutputBlobDefinition.CreateOutput(outputBlob2.blobName))
                                               .WithTaskOptions(taskOption);
 
     mock.ConfigureSubmitTaskResponse(task1,
@@ -147,7 +147,7 @@ public class TasksServiceTests
     (string taskId, string payloadId, string[]? inputs, string[]? outputs) task =
       (taskId: "taskId1", payloadId: payload.blobId, inputs: null, outputs: [outputBlob.blobId]);
     var taskDefinition = new TaskDefinition().WithOutput(outputBlob.blobName,
-                                                         BlobDefinition.CreateOutput(outputBlob.blobName))
+                                                         OutputBlobDefinition.CreateOutput(outputBlob.blobName))
                                              .WithTaskOptions(taskOption);
     mock.ConfigureSubmitTaskResponse(task);
 
@@ -210,10 +210,10 @@ public class TasksServiceTests
     (string taskId, string payloadId, string[]? inputs, string[]? outputs) task2 =
       (taskId: "taskId2", payloadId: payload2.blobId, inputs: null, outputs: [outputBlob2.blobId]);
     var taskDefinition1 = new TaskDefinition().WithOutput(outputBlob1.blobName,
-                                                          BlobDefinition.CreateOutput(outputBlob1.blobName))
+                                                          OutputBlobDefinition.CreateOutput(outputBlob1.blobName))
                                               .WithTaskOptions(taskOptions);
     var taskDefinition2 = new TaskDefinition().WithOutput(outputBlob2.blobName,
-                                                          BlobDefinition.CreateOutput(outputBlob2.blobName))
+                                                          OutputBlobDefinition.CreateOutput(outputBlob2.blobName))
                                               .WithTaskOptions(taskOptions);
     mock.ConfigureSubmitTaskResponse(task1,
                                      task2);
@@ -309,10 +309,10 @@ public class TasksServiceTests
       (taskId: "taskId1", payloadId: payload.blobId, inputs: [dependency.blobId], outputs: [outputBlob.blobId]);
     var taskDefinition = new TaskDefinition().WithTaskOptions(taskOptions)
                                              .WithInput(dependency.blobName,
-                                                        BlobDefinition.FromByteArray(dependency.blobName,
-                                                                                     [1, 2, 3]))
+                                                        InputBlobDefinition.FromByteArray(dependency.blobName,
+                                                                                          [1, 2, 3]))
                                              .WithOutput(outputBlob.blobName,
-                                                         BlobDefinition.CreateOutput(outputBlob.blobName));
+                                                         OutputBlobDefinition.CreateOutput(outputBlob.blobName));
     mock.ConfigureSubmitTaskResponse(task);
 
     var result = await client.TasksService.SubmitTasksAsync(sessionInfo,
@@ -379,10 +379,10 @@ public class TasksServiceTests
       (taskId: "taskId1", payloadId: payload.blobId, inputs: [dependency.blobId], outputs: [outputBlob.blobId]);
     var taskDefinition = new TaskDefinition().WithTaskOptions(taskOptions)
                                              .WithInput(dependency.blobName,
-                                                        BlobDefinition.FromByteArray(dependency.blobName,
-                                                                                     [1, 2, 3]))
+                                                        InputBlobDefinition.FromByteArray(dependency.blobName,
+                                                                                          [1, 2, 3]))
                                              .WithOutput(outputBlob.blobName,
-                                                         BlobDefinition.CreateOutput(outputBlob.blobName))
+                                                         OutputBlobDefinition.CreateOutput(outputBlob.blobName))
                                              .WithLibrary(lib);
     mock.ConfigureSubmitTaskResponse(task);
 
@@ -749,10 +749,10 @@ public class TasksServiceTests
       (taskId: "taskId1", payloadId: payload.blobId, inputs: [dependency.blobId], outputs: [outputBlob.blobId]);
     var taskDefinition = new TaskDefinition().WithTaskOptions(taskOptions)
                                              .WithInput("dependencyBlob",
-                                                        BlobDefinition.FromByteArray("dependencyBlob",
-                                                                                     [1, 2, 3]))
+                                                        InputBlobDefinition.FromByteArray("dependencyBlob",
+                                                                                          [1, 2, 3]))
                                              .WithOutput("output1",
-                                                         BlobDefinition.CreateOutput("output1"));
+                                                         OutputBlobDefinition.CreateOutput("output1"));
     mock.ConfigureSubmitTaskResponse(task);
 
     var result = await client.TasksService.SubmitTasksAsync(sessionInfo,
@@ -797,10 +797,10 @@ public class TasksServiceTests
       (taskId: "taskId1", payloadId: payload.blobId, inputs: [dependency.blobId], outputs: [outputBlob.blobId]);
     var taskDefinition = new TaskDefinition().WithTaskOptions(taskOptions)
                                              .WithInput("dependencyBlob",
-                                                        BlobDefinition.FromByteArray("dependencyBlob",
-                                                                                     [1, 2, 3]))
+                                                        InputBlobDefinition.FromByteArray("dependencyBlob",
+                                                                                          [1, 2, 3]))
                                              .WithOutput("output1",
-                                                         BlobDefinition.CreateOutput("output1"));
+                                                         OutputBlobDefinition.CreateOutput("output1"));
     mock.ConfigureSubmitTaskResponse(task);
 
     var result = await client.TasksService.SubmitTasksAsync(sessionInfo,

--- a/UsageExample/Program.cs
+++ b/UsageExample/Program.cs
@@ -99,10 +99,10 @@ internal class Program
 
     var task = new TaskDefinition().WithLibrary(dynamicLib)
                                    .WithInput("name",
-                                              BlobDefinition.FromString("name",
-                                                                        name))
+                                              InputBlobDefinition.FromString("name",
+                                                                             name))
                                    .WithOutput("helloResult",
-                                               BlobDefinition.CreateOutput("Result"))
+                                               OutputBlobDefinition.CreateOutput("Result"))
                                    .WithTaskOptions(defaultTaskOptions);
 
     var taskHandle = sessionHandle.Submit(task,


### PR DESCRIPTION
# Motivation

Before this change, `WithOutput` accepted any `BlobDefinition`, including one built from an already-created blob via `FromBlobHandle`. Passing an existing blob as a new output is not a valid use case, and the only thing stopping it was a runtime check inside `TaskDefinition.WithOutput`. This follows Java's approach instead, which prevents this at the type level with sealed `InputBlobDefinition`/`OutputBlobDefinition` types, applying the same split here.

# Description

`BlobDefinition` becomes an abstract base with two sealed leaves, `InputBlobDefinition` and `OutputBlobDefinition`. Constructors are `private protected`, so no third-party subclasses are possible. `InputBlobDefinition` owns `FromString`, `FromByteArray`, `FromFile`, `FromReadOnlyMemory`, and `FromBlobHandle` — the only way to reference an existing blob. `OutputBlobDefinition` owns only `CreateOutput(name)` and cannot wrap an existing handle.

The runtime check in `TaskDefinition.WithOutput` is removed. Since `WithOutput` now only accepts
`OutputBlobDefinition`, passing an existing blob as an output no longer compiles.

`WithManualDeletion()` and `WithCallback()` use `new`-hiding rather than covariant `override` returns. The client assembly targets `netstandard2.0`, which does not guarantee covariant override support — confirmed by an actual `CS8830` build error when `override` was tried first.

# Testing

# Impact

This is a breaking change: the `BlobDefinition` factory methods move to `InputBlobDefinition`/`OutputBlobDefinition`, so call sites constructing an output from an existing handle will no longer compile. This is the intended effect of the change.

# Additional Information

Kept as its own commit/branch, stacked on `jf/async-blob-handle`, so it can be reviewed and
reverted independently, should be merged after #86 

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.