### PR TITLE
feat: make worker-side BlobHandle async-native

### DIFF
--- a/ArmoniK.Extensions.CSharp.Worker.Interfaces/ArmoniK.Extensions.CSharp.Worker.Interfaces.csproj
+++ b/ArmoniK.Extensions.CSharp.Worker.Interfaces/ArmoniK.Extensions.CSharp.Worker.Interfaces.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="ArmoniK.Extensions.CSharp.Worker" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.5" />
   </ItemGroup>
 

--- a/ArmoniK.Extensions.CSharp.Worker.Interfaces/Common/Domain/Blob/BlobDefinition.cs
+++ b/ArmoniK.Extensions.CSharp.Worker.Interfaces/Common/Domain/Blob/BlobDefinition.cs
@@ -26,8 +26,9 @@ namespace ArmoniK.Extensions.CSharp.Worker.Interfaces.Common.Domain.Blob;
 /// </summary>
 public class BlobDefinition
 {
-  private readonly FileInfo? file_;
-  private          long      dataSize_;
+  private readonly FileInfo?   file_;
+  private          BlobHandle? blobHandle_;
+  private          long        dataSize_;
 
   private BlobDefinition(string                name,
                          ReadOnlyMemory<byte>? content = null)
@@ -69,9 +70,32 @@ public class BlobDefinition
     => Name.Length + dataSize_;
 
   /// <summary>
-  ///   Handle once the blob has been registered
+  ///   Handle once the blob has been registered. It is created (in a pending state) as soon as the blob definition
+  ///   is attached to a submission, and resolved once the blob is actually created; null before that.
   /// </summary>
-  public BlobHandle? BlobHandle { get; set; }
+  public BlobHandle? BlobHandle
+    => blobHandle_;
+
+  /// <summary>
+  ///   Ensures a <see cref="Handles.BlobHandle" /> exists for this definition, creating a pending one if needed.
+  ///   Idempotent and safe to call concurrently: only one <see cref="Handles.BlobHandle" /> instance ever wins.
+  /// </summary>
+  /// <param name="sdkTaskHandler">The SDK task handler to associate the pending handle with.</param>
+  /// <returns>The existing or newly created <see cref="Handles.BlobHandle" />.</returns>
+  internal BlobHandle EnsureBlobHandle(ISdkTaskHandler sdkTaskHandler)
+  {
+    var existing = blobHandle_;
+    if (existing != null)
+    {
+      return existing;
+    }
+
+    var pending = new BlobHandle(sdkTaskHandler);
+    var winner = Interlocked.CompareExchange(ref blobHandle_,
+                                             pending,
+                                             null);
+    return winner ?? pending;
+  }
 
   /// <summary>
   ///   Fetch the last state the file, whenever the blob comes from a file.
@@ -110,15 +134,20 @@ public class BlobDefinition
     => new(name);
 
   /// <summary>
-  ///   Creates a BlobDefinition from a BlobHandle
+  ///   Creates a BlobDefinition from a BlobHandle. The handle must already be resolved (i.e. reference an
+  ///   existing blob), since the blob's name is required immediately.
   /// </summary>
   /// <param name="blobHandle">The blob handle</param>
   /// <returns>The newly created BlobDefinition</returns>
+  /// <exception cref="ArmoniKSdkException">Thrown when the handle is not resolved yet.</exception>
   public static BlobDefinition FromBlobHandle(BlobHandle blobHandle)
-    => new(blobHandle.BlobId)
-       {
-         BlobHandle = blobHandle,
-       };
+  {
+    var blobId = blobHandle.ResolvedBlobIdOrNull ?? throw new ArmoniKSdkException("The blob handle must be resolved before it can be used to create a BlobDefinition.");
+    return new BlobDefinition(blobId)
+           {
+             blobHandle_ = blobHandle,
+           };
+  }
 
   /// <summary>
   ///   Creates a BlobDefinition from a file

--- a/ArmoniK.Extensions.CSharp.Worker.Interfaces/Handles/BlobHandle.cs
+++ b/ArmoniK.Extensions.CSharp.Worker.Interfaces/Handles/BlobHandle.cs
@@ -26,7 +26,18 @@ public class BlobHandle
   private readonly ISdkTaskHandler sdkTaskHandler_;
 
   /// <summary>
-  ///   Creates an of a BlobHandle
+  ///   Promise of the blob id once the blob has actually been created.
+  ///   It needs to be volatile as we need it to play the role of a barrier in GetBlobIdAsync().
+  /// </summary>
+  private volatile TaskCompletionSource<string>? blobIdSource_;
+
+  /// <summary>
+  ///   The blob id once it is known.
+  /// </summary>
+  private string? blobId_;
+
+  /// <summary>
+  ///   Creates an of a BlobHandle that is already resolved.
   /// </summary>
   /// <param name="blobId">The blob id</param>
   /// <param name="sdkTaskHandler">The SDK task handler</param>
@@ -35,20 +46,73 @@ public class BlobHandle
                     ISdkTaskHandler sdkTaskHandler,
                     byte[]?         data = null)
   {
-    BlobId          = blobId;
+    blobId_         = blobId;
     sdkTaskHandler_ = sdkTaskHandler;
     Data            = data;
   }
 
   /// <summary>
-  ///   The blob id
+  ///   Creates a BlobHandle that is not resolved yet. Its blob id will be known once
+  ///   <see cref="BlobIdSource" /> is completed.
   /// </summary>
-  public string BlobId { get; init; }
+  /// <param name="sdkTaskHandler">The SDK task handler</param>
+  internal BlobHandle(ISdkTaskHandler sdkTaskHandler)
+  {
+    sdkTaskHandler_ = sdkTaskHandler;
+    blobIdSource_   = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+  }
 
   /// <summary>
   ///   The blob raw data, null for output blobs
   /// </summary>
   public byte[]? Data { get; init; }
+
+  /// <summary>
+  ///   The TaskCompletionSource valued once the blob has actually been created, null if the handle is already resolved.
+  /// </summary>
+  internal TaskCompletionSource<string>? BlobIdSource
+    => blobIdSource_;
+
+  /// <summary>
+  ///   Whenever the handle is already resolved, returns its blob id, null otherwise.
+  /// </summary>
+  internal string? ResolvedBlobIdOrNull
+    => blobId_;
+
+  /// <summary>
+  ///   Asynchronously retrieves the blob id, waiting for the blob to be created if necessary.
+  /// </summary>
+  /// <returns>A task representing the asynchronous operation. The task result contains the blob id.</returns>
+  public ValueTask<string> GetBlobIdAsync()
+  {
+    var blobId = blobId_;
+    if (blobId is not null)
+    {
+      return new ValueTask<string>(blobId);
+    }
+
+    return Core();
+
+    async ValueTask<string> Core()
+    {
+      // volatile read of blobIdSource_ here has acquire semantics and with the combination
+      // of the volatile write of blobIdSource_ below, it ensures that if we see a null value for blobIdSource_,
+      // we are guaranteed to see a non-null value for blobId_.
+      var tcs = blobIdSource_;
+      if (tcs is null)
+      {
+        return blobId_!;
+      }
+
+      var resolvedBlobId = await tcs.Task.ConfigureAwait(false);
+      blobId_ = resolvedBlobId;
+      // volatile write of blobIdSource_ here has release semantics (allows other threads to see the effects of preceding operations).
+      // This prevent the compiler to do some operation reordering, then we are sure blobId_ has actually been assigned when we reach that point
+      // therefore if a thread can see a null blobIdSource_, it is guaranteed to see a non-null blobId_.
+      blobIdSource_ = null;
+      return resolvedBlobId;
+    }
+  }
 
   /// <summary>
   ///   Decodes the blob's data as a string with a given encoding.

--- a/ArmoniK.Extensions.CSharp.Worker/SdkTaskHandler.cs
+++ b/ArmoniK.Extensions.CSharp.Worker/SdkTaskHandler.cs
@@ -148,10 +148,14 @@ internal class SdkTaskHandler : ISdkTaskHandler
   public async Task SendResultAsync(BlobHandle         blob,
                                     byte[]             data,
                                     CancellationToken? cancellationToken = null)
-    => await taskHandler_.SendResult(blob.BlobId,
-                                     data,
-                                     cancellationToken)
-                         .ConfigureAwait(false);
+  {
+    var blobId = await blob.GetBlobIdAsync()
+                           .ConfigureAwait(false);
+    await taskHandler_.SendResult(blobId,
+                                  data,
+                                  cancellationToken)
+                      .ConfigureAwait(false);
+  }
 
   /// <summary>Send the results computed by the task</summary>
   /// <param name="blob">The blob handle.</param>
@@ -166,10 +170,14 @@ internal class SdkTaskHandler : ISdkTaskHandler
                                           string             data,
                                           Encoding?          encoding          = null,
                                           CancellationToken? cancellationToken = null)
-    => await taskHandler_.SendResult(blob.BlobId,
-                                     (encoding ?? Encoding.UTF8).GetBytes(data),
-                                     cancellationToken)
-                         .ConfigureAwait(false);
+  {
+    var blobId = await blob.GetBlobIdAsync()
+                           .ConfigureAwait(false);
+    await taskHandler_.SendResult(blobId,
+                                  (encoding ?? Encoding.UTF8).GetBytes(data),
+                                  cancellationToken)
+                      .ConfigureAwait(false);
+  }
 
   /// <summary>Submit tasks with existing payloads (results)</summary>
   /// <param name="taskDefinitions">The requests to create tasks</param>
@@ -193,11 +201,20 @@ internal class SdkTaskHandler : ISdkTaskHandler
     var payloads = new List<Payload>();
     foreach (var task in taskDefinitions)
     {
-      var inputs = task.InputDefinitions.Select(kv => new KeyValuePair<string, string>(kv.Key,
-                                                                                       kv.Value.BlobHandle!.BlobId))
-                       .ToDictionary();
-      var outputs = task.OutputDefinitions.ToDictionary(kv => kv.Key,
-                                                        kv => kv.Value.BlobHandle!.BlobId);
+      var inputs = new Dictionary<string, string>();
+      foreach (var kv in task.InputDefinitions)
+      {
+        inputs[kv.Key] = await kv.Value.BlobHandle!.GetBlobIdAsync()
+                                 .ConfigureAwait(false);
+      }
+
+      var outputs = new Dictionary<string, string>();
+      foreach (var kv in task.OutputDefinitions)
+      {
+        outputs[kv.Key] = await kv.Value.BlobHandle!.GetBlobIdAsync()
+                                  .ConfigureAwait(false);
+      }
+
       payloads.Add(new Payload(inputs,
                                outputs));
     }
@@ -214,19 +231,33 @@ internal class SdkTaskHandler : ISdkTaskHandler
       taskEnumerator.MoveNext();
       var task = taskEnumerator.Current;
       task.TaskOptions.Options[nameof(DynamicLibrary.ConventionVersion)] = DynamicLibrary.ConventionVersion;
-      var dataDependencies = task.InputDefinitions.Values.Select(b => b.BlobHandle!.BlobId);
+      var dataDependencies = new List<string>();
+      foreach (var b in task.InputDefinitions.Values)
+      {
+        dataDependencies.Add(await b.BlobHandle!.GetBlobIdAsync()
+                                    .ConfigureAwait(false));
+      }
+
       if (task.WorkerLibrary != null)
       {
         task.TaskOptions.SetDynamicLibrary(task.WorkerLibrary);
-        dataDependencies = dataDependencies.Concat([task.WorkerLibrary.LibraryBlobId]);
+        dataDependencies.Add(task.WorkerLibrary.LibraryBlobId);
+      }
+
+      var expectedOutputKeys = new List<string>();
+      foreach (var b in task.OutputDefinitions.Values)
+      {
+        expectedOutputKeys.Add(await b.BlobHandle!.GetBlobIdAsync()
+                                      .ConfigureAwait(false));
       }
 
       taskCreations.Add(new SubmitTasksRequest.Types.TaskCreation
                         {
-                          PayloadId = payloadBlobHandle.BlobId,
+                          PayloadId = await payloadBlobHandle.GetBlobIdAsync()
+                                                             .ConfigureAwait(false),
                           ExpectedOutputKeys =
                           {
-                            task.OutputDefinitions.Values.Select(b => b.BlobHandle!.BlobId),
+                            expectedOutputKeys,
                           },
                           DataDependencies =
                           {
@@ -254,12 +285,43 @@ internal class SdkTaskHandler : ISdkTaskHandler
   private async Task CreateBlobsAsync(IEnumerable<BlobDefinition> blobs,
                                       CancellationToken           cancellationToken = default)
   {
+    var definitions = blobs as ICollection<BlobDefinition> ?? blobs.ToList();
+    foreach (var blobDefinition in definitions)
+    {
+      // Ensure every definition has a (possibly pending) handle, covering callers that bypass
+      // SubmitTasksAsync's own eager creation.
+      blobDefinition.EnsureBlobHandle(this);
+    }
+
+    try
+    {
+      await CreateBlobsCoreAsync(definitions,
+                                 cancellationToken)
+        .ConfigureAwait(false);
+    }
+    catch (Exception ex)
+    {
+      // Make sure no caller is left awaiting a handle that will never resolve: every handle in this
+      // call that isn't already resolved transitions to a faulted state (idempotent, safe no-op for
+      // already-resolved ones).
+      foreach (var blobDefinition in definitions)
+      {
+        blobDefinition.BlobHandle?.BlobIdSource?.TrySetException(ex);
+      }
+
+      throw;
+    }
+  }
+
+  private async Task CreateBlobsCoreAsync(IEnumerable<BlobDefinition> blobs,
+                                          CancellationToken           cancellationToken)
+  {
     var blobsWithData    = new List<BlobDefinition>();
     var blobsWithoutData = new List<BlobDefinition>();
 
     foreach (var blob in blobs)
     {
-      if (blob.BlobHandle != null)
+      if (blob.BlobHandle!.ResolvedBlobIdOrNull != null)
       {
         continue;
       }
@@ -288,8 +350,7 @@ internal class SdkTaskHandler : ISdkTaskHandler
                                                    cancellationToken);
         await foreach (var blob in response.ConfigureAwait(false))
         {
-          name2Blob[blob.Name].BlobHandle = new BlobHandle(blob.ResultId,
-                                                           this);
+          name2Blob[blob.Name].BlobHandle!.BlobIdSource!.TrySetResult(blob.ResultId);
         }
       }
     }
@@ -312,8 +373,7 @@ internal class SdkTaskHandler : ISdkTaskHandler
                                            .ConfigureAwait(false);
           foreach (var blob in response.Results)
           {
-            name2Blob[blob.Name].BlobHandle = new BlobHandle(blob.ResultId,
-                                                             this);
+            name2Blob[blob.Name].BlobHandle!.BlobIdSource!.TrySetResult(blob.ResultId);
           }
         }
       }


### PR DESCRIPTION
# Motivation

Worker-side `BlobHandle` exposed a mutable `BlobId` that stayed unset until blob creation completed, mirroring the same race already fixed client-side in #87 . This applies the same fix to the worker.

# Description

- `BlobHandle` is now async-native: pending or resolved, with `BlobId` replaced by `GetBlobIdAsync()`.
- `BlobDefinition.BlobHandle` is read-only; a new internal `EnsureBlobHandle()` idempotently creates the pending handle.
- `SdkTaskHandler` awaits `GetBlobIdAsync()` everywhere it used to read `BlobId` synchronously.
- Failed blob creation now faults any pending handles instead of leaving them unresolved forever.

# Testing


# Impact

- Breaking: `BlobHandle.BlobId` and the `BlobDefinition.BlobHandle` setter are removed; callers must use `GetBlobIdAsync()`.
- No new dependencies or config/doc changes.

# Additional Information

Stacked on top of #87, so it needs to be merged after this.

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications

✻ Churned for 6s · 1 shell still running