### PR TITLE
feat: split worker ISdkTaskHandler.Inputs/Outputs into TaskInput/TaskOuput

### DIFF
--- a/ArmoniK.Extensions.CSharp.Worker.Interfaces/Handles/TaskInput.cs
+++ b/ArmoniK.Extensions.CSharp.Worker.Interfaces/Handles/TaskInput.cs
@@ -59,4 +59,11 @@ public sealed class TaskInput
   /// <returns>The underlying blob handle.</returns>
   public BlobHandle AsBlobHandle()
     => handle_;
+
+  /// <summary>
+  ///   Implicitly exposes the underlying blob handle, e.g. to reuse this input as another task's input.
+  /// </summary>
+  /// <param name="input">The TaskInput to convert.</param>
+  public static implicit operator BlobHandle(TaskInput input)
+    => input.handle_;
 }

--- a/ArmoniK.Extensions.CSharp.Worker.Interfaces/Handles/TaskInput.cs
+++ b/ArmoniK.Extensions.CSharp.Worker.Interfaces/Handles/TaskInput.cs
@@ -1,0 +1,62 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2026. All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Text;
+
+namespace ArmoniK.Extensions.CSharp.Worker.Interfaces.Handles;
+
+/// <summary>
+///   A read-only view of a task's input blob.
+/// </summary>
+public sealed class TaskInput
+{
+  private readonly BlobHandle handle_;
+
+  /// <summary>
+  ///   Creates a TaskInput wrapping a resolved BlobHandle.
+  /// </summary>
+  /// <param name="handle">The underlying blob handle.</param>
+  internal TaskInput(BlobHandle handle)
+    => handle_ = handle;
+
+  /// <summary>
+  ///   The input's raw data.
+  /// </summary>
+  public byte[]? RawData
+    => handle_.Data;
+
+  /// <summary>
+  ///   Asynchronously retrieves the blob id.
+  /// </summary>
+  /// <returns>A task representing the asynchronous operation. The task result contains the blob id.</returns>
+  public ValueTask<string> GetBlobIdAsync()
+    => handle_.GetBlobIdAsync();
+
+  /// <summary>
+  ///   Decodes the input's data as a string with a given encoding.
+  /// </summary>
+  /// <param name="encoding">Encoding used for the string, when null UTF-8 is used</param>
+  /// <returns>The resulting string</returns>
+  public string GetStringData(Encoding? encoding = null)
+    => handle_.GetStringData(encoding);
+
+  /// <summary>
+  ///   Exposes the underlying blob handle, e.g. to reuse this input as another task's input.
+  /// </summary>
+  /// <returns>The underlying blob handle.</returns>
+  public BlobHandle AsBlobHandle()
+    => handle_;
+}

--- a/ArmoniK.Extensions.CSharp.Worker.Interfaces/Handles/TaskOutput.cs
+++ b/ArmoniK.Extensions.CSharp.Worker.Interfaces/Handles/TaskOutput.cs
@@ -70,4 +70,11 @@ public sealed class TaskOutput
   /// <returns>The underlying blob handle.</returns>
   public BlobHandle AsBlobHandle()
     => handle_;
+
+  /// <summary>
+  ///   Implicitly exposes the underlying blob handle, e.g. to delegate this output to a sub-task.
+  /// </summary>
+  /// <param name="output">The TaskOutput to convert.</param>
+  public static implicit operator BlobHandle(TaskOutput output)
+    => output.handle_;
 }

--- a/ArmoniK.Extensions.CSharp.Worker.Interfaces/Handles/TaskOutput.cs
+++ b/ArmoniK.Extensions.CSharp.Worker.Interfaces/Handles/TaskOutput.cs
@@ -1,0 +1,73 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2026. All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Text;
+
+namespace ArmoniK.Extensions.CSharp.Worker.Interfaces.Handles;
+
+/// <summary>
+///   A write-only view of a task's output blob.
+/// </summary>
+public sealed class TaskOutput
+{
+  private readonly BlobHandle handle_;
+
+  /// <summary>
+  ///   Creates a TaskOutput wrapping a BlobHandle.
+  /// </summary>
+  /// <param name="handle">The underlying blob handle.</param>
+  internal TaskOutput(BlobHandle handle)
+    => handle_ = handle;
+
+  /// <summary>
+  ///   Asynchronously retrieves the blob id.
+  /// </summary>
+  /// <returns>A task representing the asynchronous operation. The task result contains the blob id.</returns>
+  public ValueTask<string> GetBlobIdAsync()
+    => handle_.GetBlobIdAsync();
+
+  /// <summary>
+  ///   Set the blob data
+  /// </summary>
+  /// <param name="data">The blob's data</param>
+  /// <param name="cancellationToken">Token used to cancel the execution of the method.</param>
+  /// <returns>A task representing the asynchronous operation.</returns>
+  public Task SendResultAsync(byte[]            data,
+                              CancellationToken cancellationToken = default)
+    => handle_.SendResultAsync(data,
+                               cancellationToken);
+
+  /// <summary>
+  ///   Set the blob data
+  /// </summary>
+  /// <param name="data">The string result</param>
+  /// <param name="encoding">Encoding used for the string, when null UTF-8 is used</param>
+  /// <param name="cancellationToken">Token used to cancel the execution of the method.</param>
+  /// <returns>A task representing the asynchronous operation.</returns>
+  public Task SendStringResultAsync(string            data,
+                                    Encoding?         encoding          = null,
+                                    CancellationToken cancellationToken = default)
+    => handle_.SendStringResultAsync(data,
+                                     encoding,
+                                     cancellationToken);
+
+  /// <summary>
+  ///   Exposes the underlying blob handle, e.g. to delegate this output to a sub-task.
+  /// </summary>
+  /// <returns>The underlying blob handle.</returns>
+  public BlobHandle AsBlobHandle()
+    => handle_;
+}

--- a/ArmoniK.Extensions.CSharp.Worker.Interfaces/ISdkTaskHandler.cs
+++ b/ArmoniK.Extensions.CSharp.Worker.Interfaces/ISdkTaskHandler.cs
@@ -37,23 +37,14 @@ public interface ISdkTaskHandler
   TaskConfiguration TaskOptions { get; }
 
   /// <summary>
-  ///   The data required to compute the task. The key is the name defined by the client, the value is the raw data.
+  ///   The data required to compute the task. The key is the name defined by the client.
   /// </summary>
-  public IReadOnlyDictionary<string, BlobHandle> Inputs { get; }
+  public IReadOnlyDictionary<string, TaskInput> Inputs { get; }
 
   /// <summary>
-  ///   Result blob ids by name defined by the client.
+  ///   The task's expected outputs. The key is the name defined by the client.
   /// </summary>
-  public IReadOnlyDictionary<string, BlobHandle> Outputs { get; }
-
-  /// <summary>
-  ///   Decode a dependency from its raw data
-  /// </summary>
-  /// <param name="name">The input name defined by the client</param>
-  /// <param name="encoding">Encoding used for the string, when null UTF-8 is used</param>
-  /// <returns>The decoded string</returns>
-  string GetStringDependency(string    name,
-                             Encoding? encoding = null);
+  public IReadOnlyDictionary<string, TaskOutput> Outputs { get; }
 
   /// <summary>Send the results computed by the task</summary>
   /// <param name="blob">The blob handle.</param>

--- a/ArmoniK.Extensions.CSharp.Worker/SdkTaskHandler.cs
+++ b/ArmoniK.Extensions.CSharp.Worker/SdkTaskHandler.cs
@@ -45,11 +45,11 @@ internal class SdkTaskHandler : ISdkTaskHandler
   ///   Creates a SdkTaskHandler
   /// </summary>
   /// <param name="taskHandler">The task handler</param>
-  /// <param name="inputs">The inputs with the task input name as Key, and BlobHandle as value</param>
-  /// <param name="outputs">The outputs with the task output name as Key, and BlobHandle as value</param>
+  /// <param name="inputs">The inputs with the task input name as Key</param>
+  /// <param name="outputs">The outputs with the task output name as Key</param>
   public SdkTaskHandler(ITaskHandler                            taskHandler,
-                        IReadOnlyDictionary<string, BlobHandle> inputs,
-                        IReadOnlyDictionary<string, BlobHandle> outputs)
+                        IReadOnlyDictionary<string, TaskInput>  inputs,
+                        IReadOnlyDictionary<string, TaskOutput> outputs)
   {
     taskHandler_ = taskHandler;
     Inputs       = inputs;
@@ -69,24 +69,14 @@ internal class SdkTaskHandler : ISdkTaskHandler
     => taskHandler_.TaskId;
 
   /// <summary>
-  ///   The data required to compute the task. The key is the name defined by the client, the value is the raw data.
+  ///   The data required to compute the task. The key is the name defined by the client.
   /// </summary>
-  public IReadOnlyDictionary<string, BlobHandle> Inputs { get; }
+  public IReadOnlyDictionary<string, TaskInput> Inputs { get; }
 
   /// <summary>
-  ///   Result blob ids by name defined by the client.
+  ///   The task's expected outputs. The key is the name defined by the client.
   /// </summary>
-  public IReadOnlyDictionary<string, BlobHandle> Outputs { get; }
-
-  /// <summary>
-  ///   Decode a dependency from its raw data
-  /// </summary>
-  /// <param name="name">The input name defined by the client</param>
-  /// <param name="encoding">The encoding used for the string, when null UTF-8 is used</param>
-  /// <returns>The decoded string</returns>
-  public string GetStringDependency(string    name,
-                                    Encoding? encoding = null)
-    => (encoding ?? Encoding.UTF8).GetString(Inputs[name].Data!);
+  public IReadOnlyDictionary<string, TaskOutput> Outputs { get; }
 
   /// <summary>
   ///   Create blobs metadata

--- a/ArmoniK.Extensions.CSharp.Worker/SdkTaskRunner.cs
+++ b/ArmoniK.Extensions.CSharp.Worker/SdkTaskRunner.cs
@@ -52,8 +52,8 @@ public static class SdkTaskRunner
       throw new ArmoniKSdkException($"ArmoniK SDK version '{conventionVersion}' not supported.");
     }
 
-    var dataDependencies = new Dictionary<string, BlobHandle>();
-    var expectedResults  = new Dictionary<string, BlobHandle>();
+    var dataDependencies = new Dictionary<string, TaskInput>();
+    var expectedResults  = new Dictionary<string, TaskOutput>();
     var sdkTaskHandler = new SdkTaskHandler(taskHandler,
                                             dataDependencies,
                                             expectedResults);
@@ -68,17 +68,17 @@ public static class SdkTaskRunner
         var name   = pair.Key;
         var blobId = pair.Value;
         var data   = taskHandler.DataDependencies[blobId];
-        dataDependencies[name] = new BlobHandle(blobId,
-                                                sdkTaskHandler,
-                                                data);
+        dataDependencies[name] = new TaskInput(new BlobHandle(blobId,
+                                                              sdkTaskHandler,
+                                                              data));
       }
 
       foreach (var pair in name2BlobId.Outputs)
       {
         var name   = pair.Key;
         var blobId = pair.Value;
-        expectedResults[name] = new BlobHandle(blobId,
-                                               sdkTaskHandler);
+        expectedResults[name] = new TaskOutput(new BlobHandle(blobId,
+                                                              sdkTaskHandler));
       }
     }
     catch (Exception ex)

--- a/End2EndTests/ArmoniK.EndToEndTests.Worker/Tests/CheckBlobCreationResponseOrderWorker.cs
+++ b/End2EndTests/ArmoniK.EndToEndTests.Worker/Tests/CheckBlobCreationResponseOrderWorker.cs
@@ -77,7 +77,8 @@ internal class CheckBlobCreationResponseOrderWorker : IWorker
                                  BlobDefinition.FromString(city,
                                                            city))
                       .WithOutput(city,
-                                  BlobDefinition.FromBlobHandle(taskHandler.Outputs[city]));
+                                  BlobDefinition.FromBlobHandle(taskHandler.Outputs[city]
+                                                                           .AsBlobHandle()));
       }
 
       await taskHandler.SubmitTasksAsync([taskDefinition],

--- a/End2EndTests/ArmoniK.EndToEndTests.Worker/Tests/CheckBlobCreationResponseOrderWorker.cs
+++ b/End2EndTests/ArmoniK.EndToEndTests.Worker/Tests/CheckBlobCreationResponseOrderWorker.cs
@@ -77,8 +77,7 @@ internal class CheckBlobCreationResponseOrderWorker : IWorker
                                  BlobDefinition.FromString(city,
                                                            city))
                       .WithOutput(city,
-                                  BlobDefinition.FromBlobHandle(taskHandler.Outputs[city]
-                                                                           .AsBlobHandle()));
+                                  BlobDefinition.FromBlobHandle(taskHandler.Outputs[city]));
       }
 
       await taskHandler.SubmitTasksAsync([taskDefinition],

--- a/End2EndTests/ArmoniK.EndToEndTests.Worker/Tests/GaussProblemWorker.cs
+++ b/End2EndTests/ArmoniK.EndToEndTests.Worker/Tests/GaussProblemWorker.cs
@@ -66,7 +66,7 @@ public class GaussProblemWorker : IWorker
     var             taskDefinitions    = new List<TaskDefinition>();
     var             allTaskDefinitions = new List<TaskDefinition>();
     BlobDefinition? lastBlobDefinition = null;
-    var inputs = taskHandler.Inputs.Values.Select(BlobDefinition.FromBlobHandle)
+    var inputs = taskHandler.Inputs.Values.Select(input => BlobDefinition.FromBlobHandle(input.AsBlobHandle()))
                             .ToList();
     var currentLibrary = taskHandler.TaskOptions.GetDynamicLibrary();
 
@@ -81,7 +81,8 @@ public class GaussProblemWorker : IWorker
                                        .WithInput("blob2",
                                                   inputs[1])
                                        .WithOutput("finalOutput",
-                                                   BlobDefinition.FromBlobHandle(taskHandler.Outputs.Values.Single()))
+                                                   BlobDefinition.FromBlobHandle(taskHandler.Outputs.Values.Single()
+                                                                                            .AsBlobHandle()))
                                        .WithLibrary(currentLibrary)
                                        .WithTaskOptions(taskHandler.TaskOptions);
         allTaskDefinitions.Add(task);

--- a/End2EndTests/ArmoniK.EndToEndTests.Worker/Tests/GaussProblemWorker.cs
+++ b/End2EndTests/ArmoniK.EndToEndTests.Worker/Tests/GaussProblemWorker.cs
@@ -66,7 +66,7 @@ public class GaussProblemWorker : IWorker
     var             taskDefinitions    = new List<TaskDefinition>();
     var             allTaskDefinitions = new List<TaskDefinition>();
     BlobDefinition? lastBlobDefinition = null;
-    var inputs = taskHandler.Inputs.Values.Select(input => BlobDefinition.FromBlobHandle(input.AsBlobHandle()))
+    var inputs = taskHandler.Inputs.Values.Select(input => BlobDefinition.FromBlobHandle(input))
                             .ToList();
     var currentLibrary = taskHandler.TaskOptions.GetDynamicLibrary();
 
@@ -81,8 +81,7 @@ public class GaussProblemWorker : IWorker
                                        .WithInput("blob2",
                                                   inputs[1])
                                        .WithOutput("finalOutput",
-                                                   BlobDefinition.FromBlobHandle(taskHandler.Outputs.Values.Single()
-                                                                                            .AsBlobHandle()))
+                                                   BlobDefinition.FromBlobHandle(taskHandler.Outputs.Values.Single()))
                                        .WithLibrary(currentLibrary)
                                        .WithTaskOptions(taskHandler.TaskOptions);
         allTaskDefinitions.Add(task);

--- a/End2EndTests/ArmoniK.EndToEndTests.Worker/Tests/PriorityWorker.cs
+++ b/End2EndTests/ArmoniK.EndToEndTests.Worker/Tests/PriorityWorker.cs
@@ -34,11 +34,12 @@ public class PriorityWorker : IWorker
   {
     try
     {
-      var priority  = taskHandler.GetStringDependency("Priority");
+      var priority = taskHandler.Inputs["Priority"]
+                                .GetStringData();
       var strResult = $"Payload is {priority} and TaskOptions.Priority is {taskHandler.TaskOptions.Priority}";
 
       var result = taskHandler.Outputs.Single()
-                              .Value;
+                              .Value.AsBlobHandle();
       logger.LogInformation($"Sending result: {strResult}. Task Id: {taskHandler.TaskId}");
       await taskHandler.SendResultAsync(result,
                                         Encoding.ASCII.GetBytes(strResult))

--- a/End2EndTests/ArmoniK.EndToEndTests.Worker/Tests/PriorityWorker.cs
+++ b/End2EndTests/ArmoniK.EndToEndTests.Worker/Tests/PriorityWorker.cs
@@ -39,7 +39,7 @@ public class PriorityWorker : IWorker
       var strResult = $"Payload is {priority} and TaskOptions.Priority is {taskHandler.TaskOptions.Priority}";
 
       var result = taskHandler.Outputs.Single()
-                              .Value.AsBlobHandle();
+                              .Value;
       logger.LogInformation($"Sending result: {strResult}. Task Id: {taskHandler.TaskId}");
       await taskHandler.SendResultAsync(result,
                                         Encoding.ASCII.GetBytes(strResult))


### PR DESCRIPTION
# Motivation

`ISdkTaskHandler.Inputs`/`Outputs` shared a single `BlobHandle` type, mixing input-only (`Data`) and output-only (`Send*ResultAsync`) concerns with no compile-time separation.

# Description

Splits `Inputs`/`Outputs` into dedicated `TaskInput` (read-only: `RawData`, `GetStringData`, `GetBlobIdAsync`, `AsBlobHandle`) and `TaskOutput` (write-only: `SendResultAsync`, `SendStringResultAsync`, `GetBlobIdAsync`, `AsBlobHandle`) types, mirroring the Java SDK. `AsBlobHandle()` stays on both so a sub-task can still be given an existing output/input via `BlobDefinition.FromBlobHandle(...)`. Removes `GetStringDependency`, now redundant with `Inputs[name].GetStringData()`.

Updated all call sites: `SdkTaskHandler`, `SdkTaskRunner`, `PriorityWorker`, `GaussProblemWorker`, `CheckBlobCreationResponseOrderWorker`.

# Testing

Adapted existing tests, all ok.

# Impact

Breaking API change: `Inputs`/`Outputs` types change, `GetStringDependency` is removed.

# Additional Information

Unlike the client-side split, this doesn't forbid reusing an output as a later input — worker sub-task graphs rely on that. 

Stacked on top of the changes introduced by #88, hence to be merged after it.

# Checklist

- [ ] My code adheres to the coding roject.
- [ ] I have performed a self-review
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding chan
- [ ] I have thoroughly tested my mohen necessary.
- [ ] Tests pass locally and in the
- [ ] I have assessed the performanc